### PR TITLE
Fix compilation errors on boost >=1.76

### DIFF
--- a/libmodmqttsrv/config.hpp
+++ b/libmodmqttsrv/config.hpp
@@ -2,8 +2,15 @@
 #include <cstdint>
 #include <yaml-cpp/yaml.h>
 #include "exceptions.hpp"
+#include <boost/version.hpp>
 
 namespace modmqttd {
+
+#if BOOST_VERSION >= 107600 // 1.76.0
+#define boost_dll_import boost::dll::import_symbol
+#else
+#define boost_dll_import boost::dll::import
+#endif
 
 class ConfigurationException : public ModMqttException {
     public:

--- a/libmodmqttsrv/modmqtt.cpp
+++ b/libmodmqttsrv/modmqtt.cpp
@@ -239,7 +239,7 @@ ModMqtt::initConverterPlugin(const std::string& name) {
 
     BOOST_LOG_SEV(log, Log::debug) << "Trying to load converter plugin from " << final_path;
 
-    boost::shared_ptr<ConverterPlugin> plugin = boost::dll::import<ConverterPlugin>(
+    boost::shared_ptr<ConverterPlugin> plugin = boost_dll_import<ConverterPlugin>(
         final_path,
         "converter_plugin",
         boost::dll::load_mode::append_decorations

--- a/unittests/exprconv_tests.cpp
+++ b/unittests/exprconv_tests.cpp
@@ -1,3 +1,4 @@
+#include <libmodmqttsrv/config.hpp>
 #include "catch2/catch.hpp"
 #include <boost/dll/import.hpp>
 
@@ -8,7 +9,7 @@
 TEST_CASE ("Exprtk converter test") {
     std::string stdconv_path = "../exprconv/exprconv.so";
 
-    boost::shared_ptr<ConverterPlugin> plugin = boost::dll::import<ConverterPlugin>(
+    boost::shared_ptr<ConverterPlugin> plugin = boost_dll_import<ConverterPlugin>(
         stdconv_path,
         "converter_plugin",
         boost::dll::load_mode::append_decorations
@@ -30,7 +31,7 @@ TEST_CASE ("Exprtk converter test") {
 TEST_CASE ("Exprtk converter test with precission") {
     std::string stdconv_path = "../exprconv/exprconv.so";
 
-    boost::shared_ptr<ConverterPlugin> plugin = boost::dll::import<ConverterPlugin>(
+    boost::shared_ptr<ConverterPlugin> plugin = boost_dll_import<ConverterPlugin>(
         stdconv_path,
         "converter_plugin",
         boost::dll::load_mode::append_decorations

--- a/unittests/stdconv_tests.cpp
+++ b/unittests/stdconv_tests.cpp
@@ -1,3 +1,4 @@
+#include <libmodmqttsrv/config.hpp>
 #include "catch2/catch.hpp"
 #include <boost/dll/import.hpp>
 
@@ -6,7 +7,7 @@
 TEST_CASE ("Scale value with integer result") {
     std::string stdconv_path = "../stdconv/stdconv.so";
 
-    boost::shared_ptr<ConverterPlugin> plugin = boost::dll::import<ConverterPlugin>(
+    boost::shared_ptr<ConverterPlugin> plugin = boost_dll_import<ConverterPlugin>(
         stdconv_path,
         "converter_plugin",
         boost::dll::load_mode::append_decorations


### PR DESCRIPTION
Fixes the following compilation errors:

mqmgateway/libmodmqttsrv/modmqtt.cpp: In member function \
 ‘boost::shared_ptr<ConverterPlugin> modmqttd::ModMqtt::initConverterPlugin(const string&)’:
mqmgateway/libmodmqttsrv/modmqtt.cpp:242:61: error: ‘import’ is not a member of ‘boost::dll’
  242 |     boost::shared_ptr<ConverterPlugin> plugin = boost::dll::import<ConverterPlugin>(
      |                                                             ^~~~~~
mqmgateway/libmodmqttsrv/modmqtt.cpp:242:83: error: expected primary-expression before ‘>’ token
  242 |     boost::shared_ptr<ConverterPlugin> plugin = boost::dll::import<ConverterPlugin>(
      |                                                                                   ^
mqmgateway/unittests/exprconv_tests.cpp: In function ‘void ____C_A_T_C_H____T_E_S_T____0()’:
mqmgateway/unittests/exprconv_tests.cpp:11:49: error: ‘boost_dll_import’ was not declared in this scope
   11 |     boost::shared_ptr<ConverterPlugin> plugin = boost_dll_import<ConverterPlugin>(
      |                                                 ^~~~~~~~~~~~~~~~
mqmgateway/unittests/exprconv_tests.cpp:11:81: error: expected primary-expression before ‘>’ token
   11 |     boost::shared_ptr<ConverterPlugin> plugin = boost_dll_import<ConverterPlugin>(
      |                                                                                 ^
mqmgateway/unittests/exprconv_tests.cpp: In function ‘void ____C_A_T_C_H____T_E_S_T____2()’:
mqmgateway/unittests/exprconv_tests.cpp:33:61: error: ‘import’ is not a member of ‘boost::dll’
   33 |     boost::shared_ptr<ConverterPlugin> plugin = boost::dll::import<ConverterPlugin>(
      |                                                             ^~~~~~
mqmgateway/unittests/exprconv_tests.cpp:33:83: error: expected primary-expression before ‘>’ token
   33 |     boost::shared_ptr<ConverterPlugin> plugin = boost::dll::import<ConverterPlugin>(
      |

It it caused by a breaking change introduced in boost 1.76[1].

[1] https://www.boost.org/users/history/version_1_76_0.html

Signed-off-by: Damian Wrobel <dwrobel@ertelnet.rybnik.pl>