### PR TITLE
Add support for specifying modbus register as octal or hexadecimal

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,11 +205,13 @@ A list of topics where modbus values are published to MQTT broker and subscribed
 
   * **name** (required)
 
-    A command topic name to subscribe. Full name is created as `topic.name/command.name`
+    A command topic name to subscribe. Full name is created as `topic_name/command_name`
 
   * **register** (required)
 
-    Modbus register address in the form of <network_name>.<slave_id>.<address>
+    Modbus register address in the form of `<network_name>.<slave_id>.<register_address>`
+
+    Where `register_address` is a decimal, octal or hexadecimal string (formally everything `std::stoi(3)` with base=0 accepts).
 
   *  **register_type** (required)
 

--- a/libmodmqttsrv/modbus_scheduler.cpp
+++ b/libmodmqttsrv/modbus_scheduler.cpp
@@ -27,7 +27,7 @@ ModbusScheduler::getRegistersToPoll(
             //BOOST_LOG_SEV(log, Log::debug) << "time passed: " << std::chrono::duration_cast<std::chrono::milliseconds>(time_to_poll).count();
 
             if (time_passed >= reg.mRefresh) {
-                BOOST_LOG_SEV(log, Log::debug) << "Register " << slave->first << "." << reg.mRegister
+                BOOST_LOG_SEV(log, Log::debug) << "Register " << slave->first << "." << reg.mRegister << " (0x" << std::hex << slave->first << ".0x" << std::hex << reg.mRegister << ")"
                                 << " added, last read " << std::chrono::duration_cast<std::chrono::milliseconds>(time_passed).count() << "ms ago";
                 ret[slave->first].push_back(*reg_it);
             } else {
@@ -36,7 +36,7 @@ ModbusScheduler::getRegistersToPoll(
             if (outDuration > time_to_poll) {
                 outDuration = time_to_poll;
                 BOOST_LOG_SEV(log, Log::debug) << "Wait duration set to " << std::chrono::duration_cast<std::chrono::milliseconds>(time_to_poll).count()
-                                << "ms as next poll for register " << slave->first << "." << reg.mRegister;
+                                << "ms as next poll for register " << slave->first << "." << reg.mRegister << " (0x" << std::hex << slave->first << ".0x" << std::hex << reg.mRegister << ")";
             }
         }
     }

--- a/libmodmqttsrv/modbus_thread.cpp
+++ b/libmodmqttsrv/modbus_thread.cpp
@@ -34,7 +34,7 @@ ModbusThread::pollRegisters(int slaveId, const std::vector<std::shared_ptr<Regis
             reg.mLastRead = std::chrono::steady_clock::now();
 
             std::chrono::steady_clock::time_point end = std::chrono::steady_clock::now();
-            BOOST_LOG_SEV(log, Log::debug) << "Register " << slaveId << "." << reg.mRegister
+            BOOST_LOG_SEV(log, Log::debug) << "Register " << slaveId << "." << reg.mRegister << " (0x" << std::hex << slaveId << ".0x" << std::hex << reg.mRegister << ")"
                             << " polled in " << std::chrono::duration_cast<std::chrono::milliseconds>(end - start).count() << "ms";
 
             if ((reg.mLastValue != newValue) || !sendIfChanged || (reg.mReadErrors != 0)) {

--- a/libmodmqttsrv/modmqtt.cpp
+++ b/libmodmqttsrv/modmqtt.cpp
@@ -42,7 +42,7 @@ class RegisterConfigName {
             std::string str = ConfigTools::readRequiredString(data, "register");
             boost::trim(str);
 
-            std::regex re("^([a-zA-Z0-9]+\\.)?([0-9]+\\.)?([0-9]+)$");
+            std::regex re("^([a-zA-Z0-9]+\\.)?([0-9]+\\.)?((0[xX])?[0-9]+)$");
             std::cmatch matches;
 
             if (!std::regex_match(str.c_str(), matches, re))
@@ -68,7 +68,7 @@ class RegisterConfigName {
                 throw ConfigurationException(data["register"].Mark(), "Unknown slave id in register specification");
             }
 
-            mRegisterNumber = std::stoi(matches[3]);
+            mRegisterNumber = std::stoi(matches[3], nullptr, 0);
         };
         std::string mNetworkName;
         int mSlaveId = 0;


### PR DESCRIPTION
Allows to specify modbus register address as either:
 - decimal,
 - octal,
 - hexadecimal
string (what std::stoi(3) with base=0 accepts).

Signed-off-by: Damian Wrobel <dwrobel@ertelnet.rybnik.pl>