### PR TITLE
Fix missing operators in config.hpp

### DIFF
--- a/libmodmqttsrv/config.hpp
+++ b/libmodmqttsrv/config.hpp
@@ -115,8 +115,8 @@ class MqttBrokerConfig {
         bool isSameAs(const MqttBrokerConfig& other) {
             return mHost == other.mHost &&
                     mPort == other.mPort &&
-                    mKeepalive == other.mKeepalive;
-                    mUsername == other.mUsername;
+                    mKeepalive == other.mKeepalive &&
+                    mUsername == other.mUsername &&
                     mPassword == other.mPassword;
         }
 


### PR DESCRIPTION
Fixed two missing `&&` operators which caused the isSameAs method to work incorrectly.