### PR TITLE
Fix build on Alpine Linux

### DIFF
--- a/libmodmqttsrv/modbus_thread.cpp
+++ b/libmodmqttsrv/modbus_thread.cpp
@@ -28,7 +28,7 @@ ModbusThread::pollRegisters(int slaveId, const std::vector<std::shared_ptr<Regis
     {
         try {
             std::chrono::steady_clock::time_point start = std::chrono::steady_clock::now();
-            u_int16_t newValue;
+            uint16_t newValue;
             RegisterPoll& reg(**reg_it);
             newValue = mModbus->readModbusRegister(slaveId, reg);
             reg.mLastRead = std::chrono::steady_clock::now();

--- a/modmqttd/CMakeLists.txt
+++ b/modmqttd/CMakeLists.txt
@@ -4,11 +4,14 @@ add_executable(modmqttd
     main.cpp 
 )
 
+find_package(yaml-cpp REQUIRED)
+
+
 #TODO cmake find for mosquitto libraries
 target_link_libraries(modmqttd 
     modmqttsrv
     mosquitto 
-    ${YAML_CPP_LIBRARIES} 
+    yaml-cpp
     ${Boost_LIBRARIES} 
     ${LIBMODBUS_LIBRARIES} 
     ${CMAKE_THREAD_LIBS_INIT}

--- a/stdconv/bitmask.hpp
+++ b/stdconv/bitmask.hpp
@@ -16,5 +16,5 @@ class BitmaskConverter : public IStateConverter {
 
         virtual ~BitmaskConverter() {}
     private:
-        u_int16_t mask = 0xffff;
+        uint16_t mask = 0xffff;
 };

--- a/unittests/CMakeLists.txt
+++ b/unittests/CMakeLists.txt
@@ -33,12 +33,15 @@ add_executable(tests
     two_slaves_tests.cpp
 )
 
+find_package(yaml-cpp REQUIRED)
+
+
 target_link_libraries(tests 
     modmqttsrv
     mosquittopp 
     mosquitto 
     Catch2::Catch2
-    ${YAML_CPP_LIBRARIES} 
+    yaml-cpp
     ${Boost_LIBRARIES} 
     ${LIBMODBUS_LIBRARIES} 
     ${CMAKE_THREAD_LIBS_INIT}


### PR DESCRIPTION
This pull request fixes the build of [mqmgateway](https://github.com/BlackZork/mqmgateway) on Alpine Linux.

I have replaced two usages of `u_int16_t` with `uint16_t` (u_int16_t seems to only work with glibc) and I have fixed how yaml-cpp is being linked. 