### PR TITLE
- Fix for char passed as bit count

### DIFF
--- a/libmodmqttsrv/config.cpp
+++ b/libmodmqttsrv/config.cpp
@@ -24,8 +24,8 @@ ModbusNetworkConfig::ModbusNetworkConfig(const YAML::Node& source) {
         mDevice = ConfigTools::readRequiredString(source, "device");
         mBaud = ConfigTools::readRequiredValue<int>(source, "baud");
         mParity = ConfigTools::readRequiredValue<char>(source, "parity");
-        mDataBit = ConfigTools::readRequiredValue<uint8_t>(source, "data_bit");
-        mStopBit = ConfigTools::readRequiredValue<uint8_t>(source, "stop_bit");
+        mDataBit = ConfigTools::readRequiredValue<int>(source, "data_bit");
+        mStopBit = ConfigTools::readRequiredValue<int>(source, "stop_bit");
     } else if (source["address"]) {
         mType = Type::TCPIP;
         mAddress = ConfigTools::readRequiredString(source, "address");

--- a/libmodmqttsrv/config.hpp
+++ b/libmodmqttsrv/config.hpp
@@ -100,9 +100,9 @@ class ModbusNetworkConfig {
         std::string mDevice = "";
         int mBaud = 0;
         char mParity = '\0';
-        uint8_t mDataBit = 0;
-        uint8_t mStopBit = 0;
-
+        int mDataBit = 0;
+        int mStopBit = 0;
+        
         //TCP only
         std::string mAddress = "";
         int mPort = 0;


### PR DESCRIPTION
This fixes the `data_bit` and `stop_bit` argument processing from the YAML file. Parsing it as uint8_t (char) will then pass it to the `libmodbus` as ASCII value instead (so '8' bits becomes 0x38 = 56).
Thx!