### PR TITLE
Add support for RPC to read/write Modbus register ranges

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,7 @@ set(BOOST_ALL_DYN_LINK           ON)
 
 find_package(PkgConfig)
 pkg_check_modules(LIBMODBUS REQUIRED libmodbus)
+pkg_check_modules(LIBMOSQUITTO REQUIRED libmosquitto>=2.0.0)
 
 find_package(Threads)
 

--- a/README.md
+++ b/README.md
@@ -3,19 +3,19 @@ A multithreaded C++ service that exposes data from multiple [Modbus](http://www.
 
 Main features:
 * Connects to multiple TCP and RTU modbus networks
-* Handles state and availablity for each configured MQTT object
+* Handles state and availability for each configured MQTT object
 * Allows to read and write to MODBUS registers from MQTT side with custom data conversion
 * Flexible MQTT state topic configuration:
   * single modbus register published as string value
   * multiple modbus registers as JSON object
-  * multiple modubs registers as JSON list
+  * multiple modbus registers as JSON list
   * registers from different slaves combined as single JSON list/object
 * Data conversion:
   * single register value to MQTT converters
   * multiple registers values to single MQTT value converters
   * support for [exprtk](https://github.com/ArashPartow/exprtk) expressions language when converting data
   * support for custom conversion plugins
-* Fast modbus frequency polling, configurable per newtork, per mqtt object and per register
+* Fast modbus frequency polling, configurable per network, per mqtt object and per register
 * Optimized modbus pulling - registers used in multiple MQTT topics are polled only once
 
 MQMGateway depends on [libmodbus](https://libmodbus.org/) and [Mosqutto](https://mosquitto.org/) MQTT library. See main [CMakeLists.txt](link) for full list of dependencies. It is developed under Linux, but it should be easy to port it to other platforms.
@@ -64,7 +64,7 @@ Cameron Desrochers. See license terms in [LICENSE.md](readerwriterqueue/LICENSE.
 
 # Configuration
 
-modmqttd configuration file is in YAML format. It is divied in three main sections:
+modmqttd configuration file is in YAML format. It is divided in three main sections:
 
 * modmqttd section contains information about custom plugins
 * modbus section contains modbus network definitions
@@ -157,7 +157,7 @@ The mqtt section contains broker definition and modbus register mappings. Mappin
 
   * **host** (required)
 
-    MQTT boker IP address
+    MQTT broker IP address
 
   * **port** (optional, default 1883)
 
@@ -185,7 +185,7 @@ A list of topics where modbus values are published to MQTT broker and subscribed
 
     - *commands* - for writing to modbus registers
     - *state* - for reading modbus registers
-    - *avaiability* - for checking if modbus data is available.
+    - *availability* - for checking if modbus data is available.
 
 ### Topic default values:
 
@@ -319,11 +319,11 @@ A list of topics where modbus values are published to MQTT broker and subscribed
 
 ### The *availability* section
 
-For every *state* topic there is another *availability* topic defined by default. If all data from modbus registers needed for *state* is read without errors then by default value "1" is published. If there is any network or device error when polling register data value "0" is published. This is the default behavoiur if *availability* section is not defined.
+For every *state* topic there is another *availability* topic defined by default. If all data from modbus registers needed for *state* is read without errors then by default value "1" is published. If there is any network or device error when polling register data value "0" is published. This is the default behaviour if *availability* section is not defined.
 
-Availablity flag is always published before state value. 
+Availability flag is always published before state value. 
 
-*Availability* section extends this default behaviour by defining a single or list of modbus registers that should be readed to check if state data is valid. This could be i.e. some fault indicator or hardware switch state.
+*Availability* section extends this default behaviour by defining a single or list of modbus registers that should be read to check if state data is valid. This could be i.e. some fault indicator or hardware switch state.
 
 Configuration values:
  
@@ -341,13 +341,13 @@ Configuration values:
 
   * **available_value** (optional, default 1)
 
-    Expected u_int16 value readed from availablity register when availablity flag should be set to "1". If other value is readed then availability flag is set to "0".
+    Expected `uint16` value read from availability register when availability flag should be set to "1". If other value is read then availability flag is set to "0".
 
-*register*, *register_type* and *available_value* can form a list when multiple registers should be readed.
+*register*, *register_type* and *available_value* can form a list when multiple registers should be read.
 
 ## Data conversion
 
-Data readed from modbus registers is by default converted to string and published to MQTT broker. To combine multiple modbus registers into single value, use mask to extract one bit or perform some simple divide operations a converter can be used.
+Data read from modbus registers is by default converted to string and published to MQTT broker. To combine multiple modbus registers into single value, use mask to extract one bit or perform some simple divide operations a converter can be used.
 
 ### Standard converters
 
@@ -360,7 +360,7 @@ M2MGateway contains *std* library with basic converters ready to use:
       - divider (required)
       - precision (optional)
 
-    Divides modbus value by divder and rounds to (precision) digits after the decimal.
+    Divides modbus value by divider and rounds to (precision) digits after the decimal.
 
   * **int32**
 
@@ -373,7 +373,7 @@ M2MGateway contains *std* library with basic converters ready to use:
     Arguments:
       - bitmask in hex (default "0xffff")
 
-    Applies a mask to value readed from modbus register.
+    Applies a mask to value read from modbus register.
 
 Converter can be added to modbus register in state section.
 
@@ -411,7 +411,7 @@ Here is a minimal example of custom conversion plugin with help of boost dll lib
 
 class MyConverter : public IStateConverter {
     public:
-        //called by modmqttd to set coverter arguments
+        //called by modmqttd to set converter arguments
         virtual void setArgs(const std::vector<std::string>& args) {
             mShift = getIntArg(0, args);
         }
@@ -474,5 +474,5 @@ mqtt:
 
 ```
 
-For more examples see libstdconv source code.
+For more examples see `libstdconv` source code.
 

--- a/README.md
+++ b/README.md
@@ -345,6 +345,36 @@ Configuration values:
 
 *register*, *register_type* and *available_value* can form a list when multiple registers should be read.
 
+### The *remote_call* section
+
+  The `remote_call` sections defines how to access modbus data using the MQTT remote calls (RPC).
+  In this way, value polling and availability (state) is not processed at all, and a MQTT client can be used in remote call mode to read/write register data.
+
+  The string data format is a space-separated list of value, and converters are not available.
+
+  NOTE: When at least one `remote_call` is specified, the MQTT connects using version 5, so the broker must be compatible with v5.
+
+  * **name** (required)
+
+    The last part of topic name where value should be published. Full topic name is created as `topic.name/remote_call.name`
+
+  * **register** (required)
+
+    Modbus register address in the form of <network_name>.<slave_id>.<address>
+
+  * **register_type** (required)
+
+    Modbus register type: coil, input, holding
+
+  * **size** (required)
+
+    Modbus register range count
+
+  To start a read call, publish a MQTT topic with an empty payload and with valid `response_topic` and `correlation_data` to produce the response. The response payload contains the read data, or an error message.
+
+  To start a write call, publish a MQTT topic with the register values as payload, and with valid `response_topic` and `correlation_data` to produce the empty response as acknowledge. In case of error, the response payload contains the error message.
+
+
 ## Data conversion
 
 Data read from modbus registers is by default converted to string and published to MQTT broker. To combine multiple modbus registers into single value, use mask to extract one bit or perform some simple divide operations a converter can be used.

--- a/libmodmqttsrv/config.hpp
+++ b/libmodmqttsrv/config.hpp
@@ -126,8 +126,6 @@ class MqttBrokerConfig {
         int mKeepalive = 60;
         std::string mUsername;
         std::string mPassword;
-
-        std::string mClientId;
 };
 
 }

--- a/libmodmqttsrv/config.hpp
+++ b/libmodmqttsrv/config.hpp
@@ -126,6 +126,9 @@ class MqttBrokerConfig {
         int mKeepalive = 60;
         std::string mUsername;
         std::string mPassword;
+
+        // Indirectly set if configuration requires version 5
+        bool mUseRpc;
 };
 
 }

--- a/libmodmqttsrv/imodbuscontext.hpp
+++ b/libmodmqttsrv/imodbuscontext.hpp
@@ -6,6 +6,8 @@
 namespace modmqttd {
 
 class RegisterPoll;
+class MsgRegisterReadRemoteCall;
+class MsgRegisterWriteRemoteCall;
 class MsgRegisterValue;
 class ModbusNetworkConfig;
 
@@ -19,7 +21,9 @@ class IModbusContext {
         virtual bool isConnected() const = 0;
         virtual void disconnect() = 0;
         virtual uint16_t readModbusRegister(int slaveId, const RegisterPoll& regData) = 0;
+        virtual std::vector<uint16_t> readModbusRegisters(const MsgRegisterReadRemoteCall& msg) = 0;
         virtual void writeModbusRegister(const MsgRegisterValue& msg) = 0;
+        virtual void writeModbusRegisters(const MsgRegisterWriteRemoteCall& msg) = 0;
         virtual ~IModbusContext() {};
 };
 

--- a/libmodmqttsrv/imqttimpl.hpp
+++ b/libmodmqttsrv/imqttimpl.hpp
@@ -5,6 +5,7 @@
 namespace modmqttd {
 
 class MqttClient;
+class MqttPublishProps;
 
 /**
     Abstract base class for mqtt communication library implementation
@@ -19,6 +20,7 @@ class IMqttImpl {
 
         virtual void subscribe(const char* topic) = 0;
         virtual void publish(const char* topic, int len, const void* data) = 0;
+        virtual void publish(const char* topic, int len, const void* data, const MqttPublishProps& md) = 0;
 
         virtual void on_disconnect(int rc) = 0;
         virtual void on_connect(int rc)= 0;

--- a/libmodmqttsrv/modbus_client.hpp
+++ b/libmodmqttsrv/modbus_client.hpp
@@ -23,7 +23,7 @@ class ModbusClient {
             mToModbusQueue.enqueue(QueueItem::create(config));
         };
 
-        void sendCommand(const MqttObjectCommand& cmd, uint16_t value) {
+        void sendCommand(const MqttObjectBase& cmd, uint16_t value) {
             MsgRegisterValue val(
                 cmd.mRegister.mSlaveId,
                 cmd.mRegister.mRegisterType,

--- a/libmodmqttsrv/modbus_client.hpp
+++ b/libmodmqttsrv/modbus_client.hpp
@@ -27,7 +27,7 @@ class ModbusClient {
             MsgRegisterValue val(
                 cmd.mRegister.mSlaveId,
                 cmd.mRegister.mRegisterType,
-                cmd.mRegister.mRegisterNumber,
+                cmd.mRegister.mRegisterAddress,
                 value
             );
             mToModbusQueue.enqueue(QueueItem::create(val));

--- a/libmodmqttsrv/modbus_client.hpp
+++ b/libmodmqttsrv/modbus_client.hpp
@@ -33,6 +33,31 @@ class ModbusClient {
             mToModbusQueue.enqueue(QueueItem::create(val));
         }
 
+        void sendWriteCommand(const MqttObjectBase& cmd, const std::vector<uint16_t>& value, const MqttPublishProps& responseProps) {
+            MsgRegisterWriteRemoteCall val(
+                cmd.mRegister.mSlaveId,
+                cmd.mRegister.mRegisterType,
+                cmd.mRegister.mRegisterAddress,
+                value,
+                responseProps
+            );
+            mToModbusQueue.enqueue(QueueItem::create(val));
+        }
+
+        /**
+         * Engage a Remote Call read call
+         * */
+        void sendReadCommand(const MqttObjectRemoteCall& cmd, const MqttPublishProps& responseProps) {
+            MsgRegisterReadRemoteCall val(
+                cmd.mRegister.mSlaveId,
+                cmd.mRegister.mRegisterType,
+                cmd.mRegister.mRegisterAddress,
+                cmd.mSize,
+                responseProps
+            );
+            mToModbusQueue.enqueue(QueueItem::create(val));
+        }
+
         void sendMqttNetworkIsUp(bool up) {
             mToModbusQueue.enqueue(QueueItem::create(MsgMqttNetworkState(up)));
         }

--- a/libmodmqttsrv/modbus_context.cpp
+++ b/libmodmqttsrv/modbus_context.cpp
@@ -57,24 +57,24 @@ ModbusContext::readModbusRegister(int slaveId, const RegisterPoll& regData) {
     int retCode;
     switch(regData.mRegisterType) {
         case RegisterType::COIL:
-            retCode = modbus_read_bits(mCtx, regData.mRegister, 1, &bits);
+            retCode = modbus_read_bits(mCtx, regData.mRegisterAddress, 1, &bits);
             value = bits;
         break;
         case RegisterType::BIT:
-            retCode = modbus_read_input_bits(mCtx, regData.mRegister, 1, &bits);
+            retCode = modbus_read_input_bits(mCtx, regData.mRegisterAddress, 1, &bits);
             value = bits;
         break;
         case RegisterType::HOLDING:
-            retCode = modbus_read_registers(mCtx, regData.mRegister, 1, &value);
+            retCode = modbus_read_registers(mCtx, regData.mRegisterAddress, 1, &value);
         break;
         case RegisterType::INPUT:
-            retCode = modbus_read_input_registers(mCtx, regData.mRegister, 1, &value);
+            retCode = modbus_read_input_registers(mCtx, regData.mRegisterAddress, 1, &value);
         break;
         default:
             throw ModbusContextException(std::string("Cannot read, unknown register type ") + std::to_string(regData.mRegisterType));
     }
     if (retCode == -1)
-        throw ModbusReadException(std::string("read fn ") + std::to_string(regData.mRegister) + " failed");
+        throw ModbusReadException(std::string("read fn ") + std::to_string(regData.mRegisterAddress) + " failed");
 
     return value;
 }
@@ -89,16 +89,16 @@ ModbusContext::writeModbusRegister(const MsgRegisterValue& msg) {
     int retCode;
     switch(msg.mRegisterType) {
         case RegisterType::COIL:
-            retCode = modbus_write_bit(mCtx, msg.mRegisterNumber, msg.mValue == 1 ? TRUE : FALSE);
+            retCode = modbus_write_bit(mCtx, msg.mRegisterAddress, msg.mValue == 1 ? TRUE : FALSE);
         break;
         case RegisterType::HOLDING:
-            retCode = modbus_write_register(mCtx, msg.mRegisterNumber, msg.mValue);
+            retCode = modbus_write_register(mCtx, msg.mRegisterAddress, msg.mValue);
         break;
         default:
             throw ModbusContextException(std::string("Cannot write, unknown register type ") + std::to_string(msg.mRegisterType));
     }
     if (retCode == -1)
-        throw ModbusWriteException(std::string("write fn ") + std::to_string(msg.mRegisterNumber) + " failed");
+        throw ModbusWriteException(std::string("write fn ") + std::to_string(msg.mRegisterAddress) + " failed");
 }
 
 } //namespace

--- a/libmodmqttsrv/modbus_context.hpp
+++ b/libmodmqttsrv/modbus_context.hpp
@@ -20,7 +20,9 @@ class ModbusContext : public IModbusContext {
         virtual bool isConnected() const { return mIsConnected; }
         virtual void disconnect();
         virtual uint16_t readModbusRegister(int slaveId, const RegisterPoll& regData);
+        virtual std::vector<uint16_t> readModbusRegisters(const MsgRegisterReadRemoteCall& msg);
         virtual void writeModbusRegister(const MsgRegisterValue& msg);
+        virtual void writeModbusRegisters(const MsgRegisterWriteRemoteCall& msg);
         virtual ~ModbusContext() {
             modbus_free(mCtx);
         };

--- a/libmodmqttsrv/modbus_messages.hpp
+++ b/libmodmqttsrv/modbus_messages.hpp
@@ -19,32 +19,38 @@ class MsgMqttCommand {
 
 class MsgRegisterMessageBase {
     public:
-        MsgRegisterMessageBase(int slaveId, RegisterType regType, int registerNumber)
-            : mSlaveId(slaveId), mRegisterType(regType), mRegisterNumber(registerNumber) {}
+        MsgRegisterMessageBase(int slaveId, RegisterType regType, int registerAddress)
+            : mSlaveId(slaveId), mRegisterType(regType), mRegisterAddress(registerAddress) {}
         int mSlaveId;
         RegisterType mRegisterType;
-        int mRegisterNumber;
+        int mRegisterAddress;
 };
 
 class MsgRegisterValue : public MsgRegisterMessageBase {
     public:
-        MsgRegisterValue(int slaveId, RegisterType regType, int registerNumber, int16_t value)
-            : MsgRegisterMessageBase(slaveId, regType, registerNumber),
+        MsgRegisterValue(int slaveId, RegisterType regType, int registerAddress, int16_t value)
+            : MsgRegisterMessageBase(slaveId, regType, registerAddress),
               mValue(value) {}
         int16_t mValue;
 };
 
+/**
+ * Sent back to reset availability
+ * */
 class MsgRegisterReadFailed : public MsgRegisterMessageBase {
     public:
-        MsgRegisterReadFailed(int slaveId, RegisterType regType, int registerNumber)
-            : MsgRegisterMessageBase(slaveId, regType, registerNumber)
+        MsgRegisterReadFailed(int slaveId, RegisterType regType, int registerAddress)
+            : MsgRegisterMessageBase(slaveId, regType, registerAddress)
         {}
 };
 
+/**
+ * Sent back to reset availability
+ * */
 class MsgRegisterWriteFailed : public MsgRegisterMessageBase {
     public:
-        MsgRegisterWriteFailed(int slaveId, RegisterType regType, int registerNumber)
-            : MsgRegisterMessageBase(slaveId, regType, registerNumber)
+        MsgRegisterWriteFailed(int slaveId, RegisterType regType, int registerAddress)
+            : MsgRegisterMessageBase(slaveId, regType, registerAddress)
         {}
 };
 

--- a/libmodmqttsrv/modbus_messages.hpp
+++ b/libmodmqttsrv/modbus_messages.hpp
@@ -44,6 +44,22 @@ class MsgRegisterValue : public MsgRegisterMessageBase {
         int16_t mValue;
 };
 
+class MsgRegisterReadRemoteCall : public MsgRegisterMessageBase {
+    public:
+        MsgRegisterReadRemoteCall(int slaveId, RegisterType regType, int registerAddress, int size, const MqttPublishProps& responseProps)
+            : MsgRegisterMessageBase(slaveId, regType, registerAddress), mSize(size), mResponseProps(responseProps) { }
+        int mSize;
+        MqttPublishProps mResponseProps;
+};
+
+class MsgRegisterWriteRemoteCall : public MsgRegisterMessageBase {
+    public:
+        MsgRegisterWriteRemoteCall(int slaveId, RegisterType regType, int registerAddress, const std::vector<uint16_t>& values, const MqttPublishProps& responseProps)
+            : MsgRegisterMessageBase(slaveId, regType, registerAddress), mValues(values), mResponseProps(responseProps) { }
+        std::vector<uint16_t> mValues;
+        MqttPublishProps mResponseProps;
+};
+
 /**
  * Sent back to reset availability
  * */
@@ -64,6 +80,35 @@ class MsgRegisterWriteFailed : public MsgRegisterMessageBase {
         {}
 };
 
+/**
+ * Sent back to close the Remote Call
+ * */
+class MsgRegisterRemoteCallResponseBase : public MsgRegisterMessageBase {
+    public:
+        MsgRegisterRemoteCallResponseBase(int slaveId, RegisterType regType, int registerAddress, const MqttPublishProps& props)
+            : MsgRegisterMessageBase(slaveId, regType, registerAddress), mProps(props)
+        {}
+    MqttPublishProps mProps;
+};
+
+class MsgRegisterRemoteCallResponse : public MsgRegisterRemoteCallResponseBase {
+    public:
+        MsgRegisterRemoteCallResponse(int slaveId, RegisterType regType, int registerAddress, const MqttPublishProps& responseProps)
+            : MsgRegisterRemoteCallResponseBase(slaveId, regType, registerAddress, responseProps)
+        { }
+        MsgRegisterRemoteCallResponse(int slaveId, RegisterType regType, int registerAddress, const MqttPublishProps& responseProps, const std::vector<uint16_t>& data)
+            : MsgRegisterRemoteCallResponseBase(slaveId, regType, registerAddress, responseProps), mData(data)
+        { }
+    std::vector<uint16_t> mData;
+};
+
+class MsgRegisterRemoteCallError : public MsgRegisterRemoteCallResponseBase {
+    public:
+        MsgRegisterRemoteCallError(int slaveId, RegisterType regType, int registerAddress, const MqttPublishProps& responseProps, const std::exception& exc)
+            : MsgRegisterRemoteCallResponseBase(slaveId, regType, registerAddress, responseProps), mError(exc.what())
+        { }
+    std::string mError;
+};
 
 class MsgRegisterPoll {
     public:

--- a/libmodmqttsrv/modbus_messages.hpp
+++ b/libmodmqttsrv/modbus_messages.hpp
@@ -9,6 +9,16 @@
 
 namespace modmqttd {
 
+/**
+ * Optional properties for MQTT publications
+ * */
+class MqttPublishProps {
+    public:
+        // Used in MQTT request-response
+        std::string mResponseTopic;
+        std::vector<uint8_t> mCorrelationData;
+};
+
 class MsgMqttCommand {
     public:
         int mSlave;

--- a/libmodmqttsrv/modbus_scheduler.cpp
+++ b/libmodmqttsrv/modbus_scheduler.cpp
@@ -27,7 +27,7 @@ ModbusScheduler::getRegistersToPoll(
             //BOOST_LOG_SEV(log, Log::debug) << "time passed: " << std::chrono::duration_cast<std::chrono::milliseconds>(time_to_poll).count();
 
             if (time_passed >= reg.mRefresh) {
-                BOOST_LOG_SEV(log, Log::debug) << "Register " << slave->first << "." << reg.mRegister << " (0x" << std::hex << slave->first << ".0x" << std::hex << reg.mRegister << ")"
+                BOOST_LOG_SEV(log, Log::debug) << "Register " << slave->first << "." << reg.mRegisterAddress << " (0x" << std::hex << slave->first << ".0x" << std::hex << reg.mRegisterAddress << ")"
                                 << " added, last read " << std::chrono::duration_cast<std::chrono::milliseconds>(time_passed).count() << "ms ago";
                 ret[slave->first].push_back(*reg_it);
             } else {
@@ -36,7 +36,7 @@ ModbusScheduler::getRegistersToPoll(
             if (outDuration > time_to_poll) {
                 outDuration = time_to_poll;
                 BOOST_LOG_SEV(log, Log::debug) << "Wait duration set to " << std::chrono::duration_cast<std::chrono::milliseconds>(time_to_poll).count()
-                                << "ms as next poll for register " << slave->first << "." << reg.mRegister << " (0x" << std::hex << slave->first << ".0x" << std::hex << reg.mRegister << ")";
+                                << "ms as next poll for register " << slave->first << "." << reg.mRegisterAddress << " (0x" << std::hex << slave->first << ".0x" << std::hex << reg.mRegisterAddress << ")";
             }
         }
     }

--- a/libmodmqttsrv/modbus_thread.cpp
+++ b/libmodmqttsrv/modbus_thread.cpp
@@ -213,7 +213,7 @@ ModbusThread::run() {
 
                         //initial wait set to infinity, scheduler will adjust this value
                         //to time period for next poll
-                        waitDuration = std::chrono::steady_clock::duration::max();
+                        waitDuration = std::chrono::seconds(100);
 
                         // note start time and find registers that need a refresh now
                         auto start = std::chrono::steady_clock::now();
@@ -235,7 +235,7 @@ ModbusThread::run() {
                         }
                     } else {
                         BOOST_LOG_SEV(log, Log::info) << "Waiting for mqtt network to become online";
-                        waitDuration = std::chrono::steady_clock::duration::max();
+                        waitDuration = std::chrono::seconds(2);
                     }
                 } else {
                     sendMessage(QueueItem::create(MsgModbusNetworkState(mNetworkName, false)));
@@ -251,7 +251,7 @@ ModbusThread::run() {
             //for next poll if we are exiting
             if (mShouldRun) {
                 QueueItem item;
-                BOOST_LOG_SEV(log, Log::debug) << "Waiting " <<  std::chrono::duration_cast<std::chrono::milliseconds>(waitDuration).count() << "ms for messages";
+                BOOST_LOG_SEV(log, Log::debug) << "Waiting " << std::chrono::duration_cast<std::chrono::milliseconds>(waitDuration).count() << "ms for messages";
                 if (!mToModbusQueue.wait_dequeue_timed(item, waitDuration))
                     continue;
                 dispatchMessages(item);

--- a/libmodmqttsrv/modbus_thread.cpp
+++ b/libmodmqttsrv/modbus_thread.cpp
@@ -34,15 +34,15 @@ ModbusThread::pollRegisters(int slaveId, const std::vector<std::shared_ptr<Regis
             reg.mLastRead = std::chrono::steady_clock::now();
 
             std::chrono::steady_clock::time_point end = std::chrono::steady_clock::now();
-            BOOST_LOG_SEV(log, Log::debug) << "Register " << slaveId << "." << reg.mRegister << " (0x" << std::hex << slaveId << ".0x" << std::hex << reg.mRegister << ")"
+            BOOST_LOG_SEV(log, Log::debug) << "Register " << slaveId << "." << reg.mRegisterAddress << " (0x" << std::hex << slaveId << ".0x" << std::hex << reg.mRegisterAddress << ")"
                             << " polled in " << std::chrono::duration_cast<std::chrono::milliseconds>(end - start).count() << "ms";
 
             if ((reg.mLastValue != newValue) || !sendIfChanged || (reg.mReadErrors != 0)) {
-                MsgRegisterValue val(slaveId, reg.mRegisterType, reg.mRegister, newValue);
+                MsgRegisterValue val(slaveId, reg.mRegisterType, reg.mRegisterAddress, newValue);
                 sendMessage(QueueItem::create(val));
                 reg.mLastValue = newValue;
                 reg.mReadErrors = 0;
-                BOOST_LOG_SEV(log, Log::debug) << "Register " << slaveId << "." << reg.mRegister
+                BOOST_LOG_SEV(log, Log::debug) << "Register " << slaveId << "." << reg.mRegisterAddress
                     << " value sent, data=" << reg.mLastValue;
             };
             //handle incoming write requests
@@ -60,7 +60,7 @@ ModbusThread::handleRegisterReadError(int slaveId, RegisterPoll& regPoll, const 
     regPoll.mReadErrors++;
     if (regPoll.mReadErrors == 1 || (std::chrono::steady_clock::now() - regPoll.mFirstErrorTime > RegisterPoll::DurationBetweenLogError)) {
         BOOST_LOG_SEV(log, Log::error) << regPoll.mReadErrors << " error(s) when reading register "
-            << slaveId << "." << regPoll.mRegister << ", last error: " << errorMessage;
+            << slaveId << "." << regPoll.mRegisterAddress << ", last error: " << errorMessage;
         regPoll.mFirstErrorTime = std::chrono::steady_clock::now();
         if (regPoll.mReadErrors != 1)
             regPoll.mReadErrors = 0;
@@ -68,7 +68,7 @@ ModbusThread::handleRegisterReadError(int slaveId, RegisterPoll& regPoll, const 
 
     // start sending MsgRegisterReadFailed if we cannot read register DefaultReadErrorCount times
     if (regPoll.mReadErrors > RegisterPoll::DefaultReadErrorCount) {
-        MsgRegisterReadFailed msg(slaveId, regPoll.mRegisterType, regPoll.mRegister);
+        MsgRegisterReadFailed msg(slaveId, regPoll.mRegisterType, regPoll.mRegisterAddress);
         sendMessage(QueueItem::create(msg));
     }
 }
@@ -120,23 +120,23 @@ ModbusThread::processWrite(const MsgRegisterValue& msg) {
         //are polling this register
         std::map<int, std::vector<std::shared_ptr<RegisterPoll>>>::iterator slave = mRegisters.find(msg.mSlaveId);
         if (slave != mRegisters.end()) {
-            int regNumber = msg.mRegisterNumber;
+            int regNumber = msg.mRegisterAddress;
             std::vector<std::shared_ptr<RegisterPoll>>::iterator reg_it = std::find_if(
                 slave->second.begin(), slave->second.end(),
-                [&regNumber](const std::shared_ptr<RegisterPoll>& item) -> bool { return regNumber == item->mRegister; }
+                [&regNumber](const std::shared_ptr<RegisterPoll>& item) -> bool { return regNumber == item->mRegisterAddress; }
             );
             if (reg_it != slave->second.end()) {
                 RegisterPoll& reg = **reg_it;
                 reg.mLastValue = msg.mValue;
                 reg.mLastRead = std::chrono::steady_clock::now();
-                MsgRegisterValue val(msg.mSlaveId, msg.mRegisterType, msg.mRegisterNumber, msg.mValue);
+                MsgRegisterValue val(msg.mSlaveId, msg.mRegisterType, msg.mRegisterAddress, msg.mValue);
                 sendMessage(QueueItem::create(val));
             }
         }
     } catch (const ModbusWriteException& ex) {
         BOOST_LOG_SEV(log, Log::error) << "error writing register "
-            << msg.mSlaveId << "." << msg.mRegisterNumber << ": " << ex.what();
-        MsgRegisterWriteFailed msg(msg.mSlaveId, msg.mRegisterType, msg.mRegisterNumber);
+            << msg.mSlaveId << "." << msg.mRegisterAddress << ": " << ex.what();
+        MsgRegisterWriteFailed msg(msg.mSlaveId, msg.mRegisterType, msg.mRegisterAddress);
         sendMessage(QueueItem::create(msg));
     }
 }

--- a/libmodmqttsrv/modbus_thread.hpp
+++ b/libmodmqttsrv/modbus_thread.hpp
@@ -47,6 +47,8 @@ class ModbusThread {
         void handleRegisterReadError(int slaveId, RegisterPoll& regPoll, const char* errorMessage);
 
         void processWrite(const MsgRegisterValue& msg);
+        void processWrite(const MsgRegisterWriteRemoteCall& msg);
+        void processRead(const MsgRegisterReadRemoteCall& msg);
 
         void processCommands();
 

--- a/libmodmqttsrv/modmqtt.cpp
+++ b/libmodmqttsrv/modmqtt.cpp
@@ -68,11 +68,11 @@ class RegisterConfigName {
                 throw ConfigurationException(data["register"].Mark(), "Unknown slave id in register specification");
             }
 
-            mRegisterNumber = std::stoi(matches[3], nullptr, 0);
+            mRegisterAddress = std::stoi(matches[3], nullptr, 0);
         };
         std::string mNetworkName;
         int mSlaveId = 0;
-        int mRegisterNumber;
+        int mRegisterAddress;
 };
 
 void
@@ -119,7 +119,7 @@ readCommand(const YAML::Node& node, const std::string& default_network, int defa
             rname.mNetworkName,
             rname.mSlaveId,
             rType,
-            rname.mRegisterNumber
+            rname.mRegisterAddress
             ),
         pType
     );
@@ -534,7 +534,7 @@ ModMqtt::updateSpecification(
     bool hasRefresh = parseAndAddRefresh(currentRefresh, data);
 
     MsgRegisterPoll poll;
-    poll.mRegister = rname.mRegisterNumber;
+    poll.mRegister = rname.mRegisterAddress;
     poll.mRegisterType = parseRegisterType(data);
     poll.mSlaveId = rname.mSlaveId;
     poll.mRefreshMsec = currentRefresh.top();
@@ -555,7 +555,7 @@ ModMqtt::updateSpecification(
     std::vector<MsgRegisterPoll>::iterator reg_it = std::find_if(
         spec_it->mRegisters.begin(), spec_it->mRegisters.end(),
         [&rname, &poll](const MsgRegisterPoll& r) -> bool {
-            return r.mRegister == rname.mRegisterNumber
+            return r.mRegister == rname.mRegisterAddress
                     && r.mRegisterType == poll.mRegisterType
                     && r.mSlaveId == poll.mSlaveId;
             }
@@ -666,15 +666,15 @@ ModMqtt::processModbusMessages() {
         while ((*client)->mFromModbusQueue.try_dequeue(item)) {
             if (item.isSameAs(typeid(MsgRegisterValue))) {
                 std::unique_ptr<MsgRegisterValue> val(item.getData<MsgRegisterValue>());
-                MqttObjectRegisterIdent ident((*client)->mName, val->mSlaveId, val->mRegisterType, val->mRegisterNumber);
+                MqttObjectRegisterIdent ident((*client)->mName, val->mSlaveId, val->mRegisterType, val->mRegisterAddress);
                 mMqtt->processRegisterValue(ident, val->mValue);
             } else if (item.isSameAs(typeid(MsgRegisterReadFailed))) {
                 std::unique_ptr<MsgRegisterReadFailed> val(item.getData<MsgRegisterReadFailed>());
-                MqttObjectRegisterIdent ident((*client)->mName, val->mSlaveId, val->mRegisterType, val->mRegisterNumber);
+                MqttObjectRegisterIdent ident((*client)->mName, val->mSlaveId, val->mRegisterType, val->mRegisterAddress);
                 mMqtt->processRegisterOperationFailed(ident);
             } else if (item.isSameAs(typeid(MsgRegisterWriteFailed))) {
                 std::unique_ptr<MsgRegisterWriteFailed> val(item.getData<MsgRegisterWriteFailed>());
-                MqttObjectRegisterIdent ident((*client)->mName, val->mSlaveId, val->mRegisterType, val->mRegisterNumber);
+                MqttObjectRegisterIdent ident((*client)->mName, val->mSlaveId, val->mRegisterType, val->mRegisterAddress);
                 mMqtt->processRegisterOperationFailed(ident);
             } else if (item.isSameAs(typeid(MsgModbusNetworkState))) {
                 std::unique_ptr<MsgModbusNetworkState> val(item.getData<MsgModbusNetworkState>());

--- a/libmodmqttsrv/modmqtt.hpp
+++ b/libmodmqttsrv/modmqtt.hpp
@@ -49,20 +49,21 @@ class ModMqtt {
 
         std::shared_ptr<MqttClient> mMqtt;
         std::vector<std::shared_ptr<ModbusClient>> mModbusClients;
+        std::vector<MsgRegisterPollSpecification> mSpecs;
 
         std::vector<boost::shared_ptr<ConverterPlugin>> mConverterPlugins;
 
         void initServer(const YAML::Node& config);
         void initBroker(const YAML::Node& config);
         void initModbusClients(const YAML::Node& config);
-        std::vector<MsgRegisterPollSpecification> initObjects(const YAML::Node& config);
+        void initObjects(const YAML::Node& config);
         void waitForSignal();
 
-        MqttObjectRegisterIdent updateSpecification(std::stack<int>& currentRefresh, const std::string& default_network, int default_slave, std::vector<MsgRegisterPollSpecification>& specs, const YAML::Node& data);
+        MqttObjectRegisterIdent updateSpecification(std::stack<int>& currentRefresh, const std::string& default_network, int default_slave, const YAML::Node& data);
         bool parseAndAddRefresh(std::stack<int>& values, const YAML::Node& data);
-        void readObjectState(MqttObject& object, const std::string& default_network, int default_slave, std::vector<MsgRegisterPollSpecification>& specs_out, std::stack<int>& currentRefresh, const YAML::Node& state);
-        void readObjectStateNode(MqttObject& object, const std::string& default_network, int default_slave, std::vector<MsgRegisterPollSpecification>& specs_out, std::stack<int>& currentRefresh, const std::string& stateName, const YAML::Node& node);
-        void readObjectAvailability(MqttObject& object, const std::string& default_network, int default_slave, std::vector<MsgRegisterPollSpecification>& specs_out, std::stack<int>& currentRefresh, const YAML::Node& availability);
+        void readObjectState(MqttObject& object, const std::string& default_network, int default_slave, std::stack<int>& currentRefresh, const YAML::Node& state);
+        void readObjectStateNode(MqttObject& object, const std::string& default_network, int default_slave, std::stack<int>& currentRefresh, const std::string& stateName, const YAML::Node& node);
+        void readObjectAvailability(MqttObject& object, const std::string& default_network, int default_slave, std::stack<int>& currentRefresh, const YAML::Node& availability);
         void readObjectCommands(MqttObject& object, const std::string& default_network, int default_slave, const YAML::Node& commands);
         void processModbusMessages();
 

--- a/libmodmqttsrv/modmqtt.hpp
+++ b/libmodmqttsrv/modmqtt.hpp
@@ -50,6 +50,7 @@ class ModMqtt {
         std::shared_ptr<MqttClient> mMqtt;
         std::vector<std::shared_ptr<ModbusClient>> mModbusClients;
         std::vector<MsgRegisterPollSpecification> mSpecs;
+        bool mUseRpc = false;
 
         std::vector<boost::shared_ptr<ConverterPlugin>> mConverterPlugins;
 
@@ -65,6 +66,7 @@ class ModMqtt {
         void readObjectStateNode(MqttObject& object, const std::string& default_network, int default_slave, std::stack<int>& currentRefresh, const std::string& stateName, const YAML::Node& node);
         void readObjectAvailability(MqttObject& object, const std::string& default_network, int default_slave, std::stack<int>& currentRefresh, const YAML::Node& availability);
         void readObjectCommands(MqttObject& object, const std::string& default_network, int default_slave, const YAML::Node& commands);
+        void readObjectRemoteCalls(MqttObject& object, const std::string& default_network, int default_slave, const YAML::Node& remoteCalls);
         void processModbusMessages();
 
         bool hasConverterPlugin(const std::string& name) const;

--- a/libmodmqttsrv/mosquitto.cpp
+++ b/libmodmqttsrv/mosquitto.cpp
@@ -108,7 +108,11 @@ Mosquitto::connect(const MqttBrokerConfig& config) {
     if (rc != MOSQ_ERR_SUCCESS) {
         BOOST_LOG_SEV(log, Log::error) << "Error connecting to mqtt broker: " << returnCodeToStr(rc);
     } else {
-        mosquitto_reconnect_delay_set(mMosq, 3,60, true);
+        if (config.mUseRpc) {
+            BOOST_LOG_SEV(log, Log::info) << "Using protocol version 5";
+            mosquitto_int_option(mMosq, MOSQ_OPT_PROTOCOL_VERSION, MQTT_PROTOCOL_V5);
+        }
+        mosquitto_reconnect_delay_set(mMosq, 3, 60, true);
         mosquitto_connect_callback_set(mMosq, on_connect_wrapper);
         mosquitto_connect_with_flags_callback_set(mMosq, on_connect_with_flags_wrapper);
         mosquitto_disconnect_callback_set(mMosq, on_disconnect_wrapper);

--- a/libmodmqttsrv/mosquitto.hpp
+++ b/libmodmqttsrv/mosquitto.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <mosquitto.h>
+#include <mqtt_protocol.h>
 #include "config.hpp"
 #include "common.hpp"
 #include "mqttobject.hpp"
@@ -10,6 +11,7 @@
 namespace modmqttd {
 
 class MqttClient;
+class MqttPublishProps;
 
 class Mosquitto : public IMqttImpl {
     public:
@@ -26,11 +28,12 @@ class Mosquitto : public IMqttImpl {
 
         virtual void subscribe(const char* topic);
         virtual void publish(const char* topic, int len, const void* data);
+        virtual void publish(const char* topic, int len, const void* data, const MqttPublishProps& md);
 
         virtual void on_disconnect(int rc);
         virtual void on_connect(int rc);
         virtual void on_log(int level, const char* message);
-        virtual void on_message(const struct mosquitto_message *message);
+        virtual void on_message(const struct mosquitto_message *message, const mosquitto_property *props);
         virtual ~Mosquitto();
     private:
         mosquitto *mMosq = NULL;

--- a/libmodmqttsrv/mqttclient.hpp
+++ b/libmodmqttsrv/mqttclient.hpp
@@ -23,7 +23,7 @@ class MqttClient {
         void setClientId(const std::string& clientId);
         void setBrokerConfig(const MqttBrokerConfig& config);
         void setModbusClients(const std::vector<std::shared_ptr<ModbusClient>>& clients) { mModbusClients = clients; }
-        void start() ;//TODO throw(MosquittoException) - depreciated?;
+        void start() ;//TODO throw(MosquittoException) - deprecated?;
         bool isStarted() { return mIsStarted; }
         void shutdown();
         bool isConnected() const { return mConnectionState == State::CONNECTED; }
@@ -38,6 +38,8 @@ class MqttClient {
         void processRegisterOperationFailed(const MqttObjectRegisterIdent& ident);
         void processModbusNetworkState(const std::string& networkName, bool isUp);
         void publishAvailabilityChange(const MqttObject& obj);
+        void processRemoteCallResponse(const MqttObjectRegisterIdent& ident, const MqttPublishProps& responseProps, std::vector<uint16_t> data);
+        void processRemoteCallResponseError(const MqttObjectRegisterIdent& ident, const MqttPublishProps& responseProps, std::string error);
 
         //mqtt communication callbacks
         void onDisconnect();

--- a/libmodmqttsrv/mqttclient.hpp
+++ b/libmodmqttsrv/mqttclient.hpp
@@ -42,7 +42,7 @@ class MqttClient {
         //mqtt communication callbacks
         void onDisconnect();
         void onConnect();
-        void onMessage(const char* topic, const void* payload, int payload_len);
+        void onMessage(const char* topic, const void* payload, int payload_len, const modmqttd::MqttPublishProps& md);
 
         //for unit tests
         void setMqttImplementation(const std::shared_ptr<IMqttImpl>& impl) { mMqttImpl = impl; }

--- a/libmodmqttsrv/mqttclient.hpp
+++ b/libmodmqttsrv/mqttclient.hpp
@@ -49,14 +49,14 @@ class MqttClient {
     private:
         std::shared_ptr<IMqttImpl> mMqttImpl;
 
-        void subscribeToCommandTopic(const std::string& objectName, const MqttObjectCommand& cmd);
+        void subscribeToCommandTopic(const std::string& objectName, const MqttObjectBase& cmd);
 
         boost::log::sources::severity_logger<Log::severity> log;
         ModMqtt& mOwner;
         MqttBrokerConfig mBrokerConfig;
 
         void checkAvailabilityChange(MqttObject& object, const MqttObjectRegisterIdent& ident, uint16_t value);
-        const MqttObjectCommand& findCommand(const char* topic) const;
+        const MqttObjectBase& findCommand(const char* topic) const;
 
         std::vector<std::shared_ptr<ModbusClient>> mModbusClients;
 

--- a/libmodmqttsrv/mqttobject.cpp
+++ b/libmodmqttsrv/mqttobject.cpp
@@ -119,7 +119,7 @@ MqttObjectAvailability::getAvailableFlag() const {
             break;
             case AvailableFlag::False:
                 return AvailableFlag::False;
-            break;
+                break;
             case AvailableFlag::True:
                 continue;
             break;
@@ -343,7 +343,7 @@ MqttObject::updateRegisterValue(const MqttObjectRegisterIdent& regIdent, uint16_
     bool stateChanged = mState.updateRegisterValue(regIdent, value);
     bool availChanged = mAvailability.updateRegisterValue(regIdent, value);
     if (stateChanged || availChanged)
-        updateAvailablityFlag();
+        updateAvailabilityFlag();
 }
 
 void
@@ -351,7 +351,7 @@ MqttObject::updateRegisterReadFailed(const MqttObjectRegisterIdent& regIdent) {
     bool stateChanged = mState.updateRegisterReadFailed(regIdent);
     bool availChanged = mAvailability.updateRegisterReadFailed(regIdent);
     if (stateChanged || availChanged)
-        updateAvailablityFlag();
+        updateAvailabilityFlag();
 }
 
 void
@@ -359,11 +359,11 @@ MqttObject::setModbusNetworkState(const std::string& networkName, bool isUp) {
     bool stateChanged = mState.setModbusNetworkState(networkName, isUp);
     bool availChanged = mAvailability.setModbusNetworkState(networkName, isUp);
     if (stateChanged || availChanged)
-        updateAvailablityFlag();
+        updateAvailabilityFlag();
 }
 
 void
-MqttObject::updateAvailablityFlag() {
+MqttObject::updateAvailabilityFlag() {
     // if we cannot read availability registers
     // then assume that state data is invalid
     if (!mAvailability.isPolling() || !mState.isPolling())
@@ -374,7 +374,7 @@ MqttObject::updateAvailablityFlag() {
         if (!mAvailability.hasValue() || !mState.hasValues()) {
             mIsAvailable = AvailableFlag::NotSet;
         } else {
-            //we have all values, check avaiabilty registers
+            //we have all values, check availability registers
             mIsAvailable = mAvailability.getAvailableFlag();
         }
     }

--- a/libmodmqttsrv/mqttobject.hpp
+++ b/libmodmqttsrv/mqttobject.hpp
@@ -21,8 +21,8 @@ class MqttObjectRegisterIdent {
     public:
         struct Compare {
             bool operator() (const MqttObjectRegisterIdent& left, const MqttObjectRegisterIdent& right) const {
-                return std::tie(left.mNetworkName, left.mSlaveId, left.mRegisterNumber, left.mRegisterType)
-                        < std::tie(right.mNetworkName, right.mSlaveId, right.mRegisterNumber, right.mRegisterType);
+                return std::tie(left.mNetworkName, left.mSlaveId, left.mRegisterAddress, left.mRegisterType)
+                        < std::tie(right.mNetworkName, right.mSlaveId, right.mRegisterAddress, right.mRegisterType);
             }
         };
         MqttObjectRegisterIdent(
@@ -32,12 +32,12 @@ class MqttObjectRegisterIdent {
             int registerNumber
         ) : mNetworkName(network),
             mSlaveId(slaveId),
-            mRegisterNumber(registerNumber),
+            mRegisterAddress(registerNumber),
             mRegisterType(regType)
         {}
         std::string mNetworkName;
         int mSlaveId;
-        int mRegisterNumber;
+        int mRegisterAddress;
         RegisterType mRegisterType;
 };
 

--- a/libmodmqttsrv/mqttobject.hpp
+++ b/libmodmqttsrv/mqttobject.hpp
@@ -66,6 +66,13 @@ class MqttObjectCommand : public MqttObjectBase {
             : MqttObjectBase(typeid(MqttObjectCommand).hash_code(), name, ident, ptype) {}
 };
 
+class MqttObjectRemoteCall : public MqttObjectBase {
+    public:
+        MqttObjectRemoteCall(const std::string& name, const MqttObjectRegisterIdent& ident, PayloadType ptype, int size)
+            : MqttObjectBase(typeid(MqttObjectRemoteCall).hash_code(), name, ident, ptype), mSize(size) {}
+        int mSize;
+};
+
 class MqttObjectRegisterValue {
     public:
         MqttObjectRegisterValue(uint16_t val) : mValue(val), mHasValue(true), mReadOk(true) {}
@@ -163,6 +170,7 @@ class MqttObject {
         bool hasCommand(const std::string& name) const;
 
         std::vector<MqttObjectCommand> mCommands;
+        std::vector<MqttObjectRemoteCall> mRemoteCalls;
         MqttObjectState mState;
         MqttObjectAvailability mAvailability;
 

--- a/libmodmqttsrv/mqttobject.hpp
+++ b/libmodmqttsrv/mqttobject.hpp
@@ -160,7 +160,7 @@ class MqttObject {
         std::string mAvailabilityTopic;
         AvailableFlag mIsAvailable = AvailableFlag::NotSet;
 
-        void updateAvailablityFlag();
+        void updateAvailabilityFlag();
 };
 
 }

--- a/libmodmqttsrv/mqttobject.hpp
+++ b/libmodmqttsrv/mqttobject.hpp
@@ -41,16 +41,29 @@ class MqttObjectRegisterIdent {
         RegisterType mRegisterType;
 };
 
-class MqttObjectCommand {
+class MqttObjectBase {
+    private:
+        size_t mTypeHash;
     public:
         enum PayloadType {
             STRING = 1
         };
-        MqttObjectCommand(const std::string& name, const MqttObjectRegisterIdent& ident, PayloadType ptype)
-            : mName(name), mRegister(ident), mPayloadType(ptype) {}
         std::string mName;
         PayloadType mPayloadType;
         MqttObjectRegisterIdent mRegister;
+
+        bool isSameAs(const std::type_info& type) const {
+            return type.hash_code() == mTypeHash;
+        }
+    protected:
+        MqttObjectBase(size_t typeHash, const std::string& name, const MqttObjectRegisterIdent& ident, PayloadType ptype)
+            : mTypeHash(typeHash), mName(name), mRegister(ident), mPayloadType(ptype) {}
+};
+
+class MqttObjectCommand : public MqttObjectBase {
+    public:
+        MqttObjectCommand(const std::string& name, const MqttObjectRegisterIdent& ident, PayloadType ptype)
+            : MqttObjectBase(typeid(MqttObjectCommand).hash_code(), name, ident, ptype) {}
 };
 
 class MqttObjectRegisterValue {

--- a/libmodmqttsrv/register_poll.cpp
+++ b/libmodmqttsrv/register_poll.cpp
@@ -4,9 +4,9 @@ namespace modmqttd {
 
 constexpr std::chrono::steady_clock::duration RegisterPoll::DurationBetweenLogError;
 
-RegisterPoll::RegisterPoll(int regNum, RegisterType regType, int refreshMsec)
-    : mLastRead(std::chrono::steady_clock::now() - std::chrono::hours(24)),
-    mRegister(regNum),
+RegisterPoll::RegisterPoll(int registerAddress, RegisterType regType, int refreshMsec)
+    : mLastRead(std::chrono::steady_clock::now() - std::chrono::hours(24)), 
+    mRegisterAddress(registerAddress), 
     mRegisterType(regType)
 {
     mRefresh = std::chrono::milliseconds(refreshMsec);

--- a/libmodmqttsrv/register_poll.hpp
+++ b/libmodmqttsrv/register_poll.hpp
@@ -10,8 +10,8 @@ class RegisterPoll {
         static constexpr std::chrono::steady_clock::duration DurationBetweenLogError = std::chrono::minutes(5);
         // if we cannot read register in this time MsgRegisterReadFailed is sent
         static constexpr int DefaultReadErrorCount = 3;
-        RegisterPoll(int regNum, RegisterType regType, int refreshMsec);
-        int mRegister;
+        RegisterPoll(int registerAddress, RegisterType regType, int refreshMsec);
+        int mRegisterAddress;
         RegisterType mRegisterType;
         std::chrono::steady_clock::duration mRefresh;
         uint16_t mLastValue;

--- a/modmqttd/config.template.yaml
+++ b/modmqttd/config.template.yaml
@@ -83,5 +83,11 @@ mqtt:
         register_type: input
         refresh: 1s
 
-
+    - topic: rpc_sensor/generic
+      remote_calls:
+        # Expose a range of 12 holding registries to remote calls (R/W)
+        name: calibration_data
+        register: rtutest.2.1024
+        register_type: holding
+        size: 12
 

--- a/unittests/CMakeLists.txt
+++ b/unittests/CMakeLists.txt
@@ -33,6 +33,7 @@ add_executable(tests
     single_register_tests.cpp
     stdconv_tests.cpp
     two_slaves_tests.cpp
+    mqtt_remote_call_tests.cpp
 )
 
 target_link_libraries(tests 

--- a/unittests/mockedmodbuscontext.cpp
+++ b/unittests/mockedmodbuscontext.cpp
@@ -16,25 +16,25 @@ MockedModbusContext::Slave::write(const modmqttd::MsgRegisterValue& msg, bool in
         std::this_thread::sleep_for(mWriteTime);
         if (mDisconnected) {
             errno = EIO;
-            throw modmqttd::ModbusWriteException(std::string("write fn ") + std::to_string(msg.mRegisterNumber) + " failed");
+            throw modmqttd::ModbusWriteException(std::string("write fn ") + std::to_string(msg.mRegisterAddress) + " failed");
         }
-        if (hasError(msg.mRegisterNumber, msg.mRegisterType)) {
+        if (hasError(msg.mRegisterAddress, msg.mRegisterType)) {
             errno = EIO;
-            throw modmqttd::ModbusReadException(std::string("register write fn ") + std::to_string(msg.mRegisterNumber) + " failed");
+            throw modmqttd::ModbusReadException(std::string("register write fn ") + std::to_string(msg.mRegisterAddress) + " failed");
         }
     }
     switch(msg.mRegisterType) {
         case modmqttd::RegisterType::COIL:
-            mCoil[msg.mRegisterNumber].mValue = msg.mValue == 1;
+            mCoil[msg.mRegisterAddress].mValue = msg.mValue == 1;
         break;
         case modmqttd::RegisterType::BIT:
-            mBit[msg.mRegisterNumber].mValue = msg.mValue == 1;
+            mBit[msg.mRegisterAddress].mValue = msg.mValue == 1;
         break;
         case modmqttd::RegisterType::HOLDING:
-            mHolding[msg.mRegisterNumber].mValue = msg.mValue;
+            mHolding[msg.mRegisterAddress].mValue = msg.mValue;
         break;
         case modmqttd::RegisterType::INPUT:
-            mInput[msg.mRegisterNumber].mValue = msg.mValue;
+            mInput[msg.mRegisterAddress].mValue = msg.mValue;
         break;
         default:
             throw modmqttd::ModbusWriteException(std::string("Cannot write, unknown register type ") + std::to_string(msg.mRegisterType));
@@ -47,25 +47,25 @@ MockedModbusContext::Slave::read(const modmqttd::RegisterPoll& regData, bool int
         std::this_thread::sleep_for(mReadTime);
         if (mDisconnected) {
             errno = EIO;
-            throw modmqttd::ModbusReadException(std::string("read fn ") + std::to_string(regData.mRegister) + " failed");
+            throw modmqttd::ModbusReadException(std::string("read fn ") + std::to_string(regData.mRegisterAddress) + " failed");
         }
-        if (hasError(regData.mRegister, regData.mRegisterType)) {
+        if (hasError(regData.mRegisterAddress, regData.mRegisterType)) {
             errno = EIO;
-            throw modmqttd::ModbusReadException(std::string("register read fn ") + std::to_string(regData.mRegister) + " failed");
+            throw modmqttd::ModbusReadException(std::string("register read fn ") + std::to_string(regData.mRegisterAddress) + " failed");
         }
     }
     switch(regData.mRegisterType) {
         case modmqttd::RegisterType::COIL:
-            return readRegister(mCoil, regData.mRegister);
+            return readRegister(mCoil, regData.mRegisterAddress);
         break;
         case modmqttd::RegisterType::HOLDING:
-            return readRegister(mHolding, regData.mRegister);
+            return readRegister(mHolding, regData.mRegisterAddress);
         break;
         case modmqttd::RegisterType::INPUT:
-            return readRegister(mInput, regData.mRegister);
+            return readRegister(mInput, regData.mRegisterAddress);
         break;
         case modmqttd::RegisterType::BIT:
-            return readRegister(mBit, regData.mRegister);
+            return readRegister(mBit, regData.mRegisterAddress);
         break;
         default:
             throw modmqttd::ModbusReadException(std::string("Cannot read, unknown register type ") + std::to_string(regData.mRegisterType));
@@ -138,7 +138,7 @@ MockedModbusContext::readModbusRegister(int slaveId, const modmqttd::RegisterPol
     uint16_t ret = it->second.read(regData, mInternalOperation);
     if (mInternalOperation)
         BOOST_LOG_SEV(log, modmqttd::Log::info) << "MODBUS: " << mNetworkName
-            << "." << it->second.mId << "." << regData.mRegister
+            << "." << it->second.mId << "." << regData.mRegisterAddress
             << " READED: " << ret;
 
     mInternalOperation = false;
@@ -157,7 +157,7 @@ MockedModbusContext::writeModbusRegister(const modmqttd::MsgRegisterValue& msg) 
 
     if (mInternalOperation)
         BOOST_LOG_SEV(log, modmqttd::Log::info) << "MODBUS: " << mNetworkName
-            << "." << it->second.mId << "." << msg.mRegisterNumber
+            << "." << it->second.mId << "." << msg.mRegisterAddress
             << " WRITE: " << msg.mValue;
     it->second.write(msg, mInternalOperation);
     mInternalOperation = false;

--- a/unittests/mockedmodbuscontext.hpp
+++ b/unittests/mockedmodbuscontext.hpp
@@ -6,6 +6,7 @@
 #include <mutex>
 
 #include "libmodmqttsrv/imodbuscontext.hpp"
+#include "libmodmqttsrv/modbus_messages.hpp"
 #include "libmodmqttsrv/modbus_types.hpp"
 #include "libmodmqttsrv/logging.hpp"
 
@@ -18,11 +19,14 @@ class MockedModbusContext : public modmqttd::IModbusContext {
             struct RegData {
                 uint16_t mValue;
                 bool mError;
+                int mReadCount;
             };
             public:
                 Slave(int id = 0) : mId(id) {}
-                void write(const modmqttd::MsgRegisterValue& msg, bool internalOperation = false);
-                uint16_t read(const modmqttd::RegisterPoll& regData, bool internalOperation = false);
+                void write(int registerAddress, modmqttd::RegisterType registerType, uint16_t value, bool internalOperation = false);
+                uint16_t read(int registerAddress, modmqttd::RegisterType registerType, bool internalOperation = false);
+
+                int getReadCount(int regNum, modmqttd::RegisterType registerType);
 
                 void setDisconnected(bool flag = true) { mDisconnected = flag; }
                 void setError(int regNum, modmqttd::RegisterType regType, bool flag = true);
@@ -41,7 +45,7 @@ class MockedModbusContext : public modmqttd::IModbusContext {
 
             private:
                 bool hasError(const std::map<int, MockedModbusContext::Slave::RegData>& table, int num) const;
-                uint16_t readRegister(std::map<int, RegData>& table, int num);
+                uint16_t readRegister(std::map<int, RegData>& table, int num, bool internalOperation);
                 bool mDisconnected = false;
         };
 
@@ -50,9 +54,12 @@ class MockedModbusContext : public modmqttd::IModbusContext {
         virtual bool isConnected() const { return mIsConnected; }
         virtual void disconnect() { mIsConnected = false; }
         virtual uint16_t readModbusRegister(int slaveId, const modmqttd::RegisterPoll& regData);
+        virtual std::vector<uint16_t> readModbusRegisters(const modmqttd::MsgRegisterReadRemoteCall& msg);
         virtual void writeModbusRegister(const modmqttd::MsgRegisterValue& msg);
+        virtual void writeModbusRegisters(const modmqttd::MsgRegisterWriteRemoteCall& msg);
 
         Slave& getSlave(int slaveId);
+        int getRegisterReadCount(int slaveId, int registerAddress, modmqttd::RegisterType registerType);
 
         bool mIsConnected = false;
         bool mInternalOperation = false;
@@ -80,8 +87,10 @@ class MockedModbusFactory : public modmqttd::IModbusFactory {
             return ctx;
         };
 
+        uint16_t getModbusRegisterValue(const char* network, int slaveId, int regNum, modmqttd::RegisterType regtype);
         void setModbusRegisterValue(const char* network, int slaveId, int regNum, modmqttd::RegisterType regtype, uint16_t val);
-        void setModbusRegisterReadError(const char* network, int slaveId, int regNum, modmqttd::RegisterType regtype);
+        void setModbusRegisterError(const char* network, int slaveId, int regNum, modmqttd::RegisterType regtype);
+        int getRegisterReadCount(const char* network, int slaveId, int regNum, modmqttd::RegisterType regtype);
         void disconnectModbusSlave(const char* network, int slaveId);
     private:
         std::shared_ptr<MockedModbusContext> getOrCreateContext(const char* network);

--- a/unittests/mockedmqttimpl.hpp
+++ b/unittests/mockedmqttimpl.hpp
@@ -7,6 +7,7 @@
 
 #include "libmodmqttsrv/imqttimpl.hpp"
 #include "libmodmqttsrv/logging.hpp"
+#include "libmodmqttsrv/mqttobject.hpp"
 
 class MockedMqttException : public modmqttd::ModMqttException {
     public:
@@ -20,11 +21,17 @@ class MockedMqttImpl : public modmqttd::IMqttImpl {
             MqttValue(const void* v, int l) {
                 copyData(v, l);
             }
+            MqttValue(const void* v, int l, modmqttd::MqttPublishProps props) 
+                :mProps(props) {
+                    copyData(v, l);
+                }
             MqttValue(const MqttValue& from) {
                 copyData(from.val, from.len);
+                mProps = from.mProps;
             }
             MqttValue& operator=(const MqttValue& other) {
                 copyData(other.val, other.len);
+                mProps = other.mProps;
                 return *this;
             }
             ~MqttValue() {
@@ -33,6 +40,7 @@ class MockedMqttImpl : public modmqttd::IMqttImpl {
             }
             char* val = NULL;
             int len = 0;
+            modmqttd::MqttPublishProps mProps;
         private:
             void copyData(const void* v, int l) {
                 if (val)
@@ -52,6 +60,8 @@ class MockedMqttImpl : public modmqttd::IMqttImpl {
 
         virtual void subscribe(const char* topic);
         virtual void publish(const char* topic, int len, const void* data);
+        virtual void publish(const char* topic, int len, const void* data, const modmqttd::MqttPublishProps& md);
+        void publish(const char* topic, int len, const void* data, modmqttd::MqttObjectBase::PayloadType payloadType);
 
         virtual void on_disconnect(int rc);
         virtual void on_connect(int rc);
@@ -62,6 +72,8 @@ class MockedMqttImpl : public modmqttd::IMqttImpl {
         std::string waitForFirstPublish(std::chrono::milliseconds timeout);
         bool hasTopic(const char* topic);
         std::string mqttValue(const char* topic);
+        modmqttd::MqttPublishProps mqttValueProps(const char* topic);
+
         //returns current value on timeout
         std::string waitForMqttValue(const char* topic, const char* expected, std::chrono::milliseconds timeout = std::chrono::seconds(1));
         //clear all topics and simulate broker disconnection

--- a/unittests/mockedserver.hpp
+++ b/unittests/mockedserver.hpp
@@ -79,6 +79,11 @@ class MockedModMqttServerThread : public ModMqttServerThread {
         REQUIRE(is_published == true);
     }
 
+    bool checkForPublish(const char* topic, std::chrono::milliseconds timeout = std::chrono::milliseconds(100)) {
+        INFO("Checking for publish on " << topic);
+        return mMqtt->waitForPublish(topic, timeout);
+    }
+
     std::string waitForFirstPublish(std::chrono::milliseconds timeout = std::chrono::milliseconds(100)) {
         std::string topic = mMqtt->waitForFirstPublish(timeout);
         INFO("Getting first published topic");
@@ -88,6 +93,10 @@ class MockedModMqttServerThread : public ModMqttServerThread {
 
     void publish(const char* topic, const std::string& value) {
         mMqtt->publish(topic, value.length(), value.c_str());
+    }
+
+    void publish(const char* topic, const std::string& value, const modmqttd::MqttPublishProps& props) {
+        mMqtt->publish(topic, value.length(), value.c_str(), props);
     }
 
     void waitForMqttValue(const char* topic, const char* expected, std::chrono::milliseconds timeout = std::chrono::milliseconds(100)) {
@@ -101,16 +110,30 @@ class MockedModMqttServerThread : public ModMqttServerThread {
         return mMqtt->mqttValue(topic);
     }
 
+    modmqttd::MqttPublishProps mqttValueProps(const char* topic) {
+        bool has_topic = mMqtt->hasTopic(topic);
+        REQUIRE(has_topic);
+        return mMqtt->mqttValueProps(topic);
+    }
+
     void setModbusRegisterValue(const char* network, int slaveId, int regNum, modmqttd::RegisterType regtype, uint16_t val) {
         mModbusFactory->setModbusRegisterValue(network, slaveId, regNum, regtype, val);
+    }
+
+    uint16_t getModbusRegisterValue(const char* network, int slaveId, int regNum, modmqttd::RegisterType regtype) {
+        return mModbusFactory->getModbusRegisterValue(network, slaveId, regNum, regtype);
+    }
+
+    int getModbusRegisterReadCount(const char* network, int slaveId, int regNum, modmqttd::RegisterType regType) {
+        return mModbusFactory->getRegisterReadCount(network, slaveId, regNum, regType);
     }
 
     void disconnectModbusSlave(const char* network, int slaveId) {
         mModbusFactory->disconnectModbusSlave(network, slaveId);
     }
 
-    void setModbusRegisterReadError(const char* network, int slaveId, int regNum, modmqttd::RegisterType regtype) {
-        mModbusFactory->setModbusRegisterReadError(network, slaveId, regNum, regtype);
+    void setModbusRegisterError(const char* network, int slaveId, int regNum, modmqttd::RegisterType regtype) {
+        mModbusFactory->setModbusRegisterError(network, slaveId, regNum, regtype);
     }
 
     std::shared_ptr<MockedModbusFactory> mModbusFactory;

--- a/unittests/mqtt_command_tests.cpp
+++ b/unittests/mqtt_command_tests.cpp
@@ -23,19 +23,39 @@ mqtt:
         register_type: holding
 )";
 
+// Better stack print in case of failure
+#define REQUIRE_PUBLISH(server, topic, timeout) REQUIRE(server.checkForPublish(topic, timeout) == true)
+
 TEST_CASE ("Holding register valid write") {
     MockedModMqttServerThread server(config);
     server.setModbusRegisterValue("tcptest", 1, 2, modmqttd::RegisterType::HOLDING, 0);
+    server.start();
+
+    REQUIRE_PUBLISH(server, "test_switch/availability", REGWAIT_MSEC);
+    REQUIRE(server.mqttValue("test_switch/availability") == "1");
+    REQUIRE_PUBLISH(server, "test_switch/state", REGWAIT_MSEC);
+
+    server.publish("test_switch/set", "32");
+
+    REQUIRE_PUBLISH(server, "test_switch/state", REGWAIT_MSEC);
+    REQUIRE(server.mqttValue("test_switch/state") == "32");
+
+    server.stop();
+}
+
+TEST_CASE ("Holding register valid write, negative value are invalid") {
+    MockedModMqttServerThread server(config);
+    server.setModbusRegisterValue("tcptest", 1, 2, modmqttd::RegisterType::HOLDING, 42);
     server.start();
 
     server.waitForPublish("test_switch/availability", REGWAIT_MSEC);
     REQUIRE(server.mqttValue("test_switch/availability") == "1");
     server.waitForPublish("test_switch/state", REGWAIT_MSEC);
 
-    server.publish("test_switch/set", "32");
+    server.publish("test_switch/set", "-32");
 
-    server.waitForPublish("test_switch/state", REGWAIT_MSEC);
-    REQUIRE(server.mqttValue("test_switch/state") == "32");
+    REQUIRE(server.mMqtt->waitForPublish("test_switch/state", REGWAIT_MSEC) == false);
+    REQUIRE(server.getModbusRegisterValue("tcptest", 1, 2, modmqttd::RegisterType::HOLDING) == 42);
 
     server.stop();
 }
@@ -45,13 +65,12 @@ TEST_CASE ("Coil register valid write") {
     server.setModbusRegisterValue("tcptest", 1, 2, modmqttd::RegisterType::COIL, 0);
     server.start();
 
-    server.waitForPublish("test_switch/availability", REGWAIT_MSEC);
+    REQUIRE_PUBLISH(server, "test_switch/availability", REGWAIT_MSEC);
     REQUIRE(server.mqttValue("test_switch/availability") == "1");
-    server.waitForPublish("test_switch/state", REGWAIT_MSEC);
+    REQUIRE_PUBLISH(server, "test_switch/state", REGWAIT_MSEC);
 
     server.publish("test_switch/set", "1");
-
-    server.waitForPublish("test_switch/state", REGWAIT_MSEC);
+    REQUIRE_PUBLISH(server, "test_switch/state", REGWAIT_MSEC);
     REQUIRE(server.mqttValue("test_switch/state") == "1");
 
     server.stop();
@@ -62,19 +81,35 @@ TEST_CASE ("Mqtt invalid value should not crash server") {
     server.setModbusRegisterValue("tcptest", 1, 2, modmqttd::RegisterType::COIL, 0);
     server.start();
 
-
-    server.waitForPublish("test_switch/availability", REGWAIT_MSEC);
+    REQUIRE_PUBLISH(server, "test_switch/availability", REGWAIT_MSEC);
     REQUIRE(server.mqttValue("test_switch/availability") == "1");
-    server.waitForPublish("test_switch/state", REGWAIT_MSEC);
+    REQUIRE_PUBLISH(server, "test_switch/state", REGWAIT_MSEC);
+
+    server.publish("test_switch/set", "1");
+    REQUIRE_PUBLISH(server, "test_switch/state", REGWAIT_MSEC);
+    REQUIRE(server.mqttValue("test_switch/state") == "1");
 
     server.publish("test_switch/set", "hello, world!");
-    server.publish("test_switch/set", "1");
-    server.waitForPublish("test_switch/state", REGWAIT_MSEC);
+    REQUIRE(server.checkForPublish("test_switch/state", REGWAIT_MSEC) == false);
     REQUIRE(server.mqttValue("test_switch/state") == "1");
 
     server.stop();
 }
 
+TEST_CASE ("Mqtt register range value should not be permitted if not configured") {
+    MockedModMqttServerThread server(config);
+    server.setModbusRegisterValue("tcptest", 1, 2, modmqttd::RegisterType::HOLDING, 42);
+    server.start();
+
+    REQUIRE_PUBLISH(server, "test_switch/availability", REGWAIT_MSEC);
+    REQUIRE(server.mqttValue("test_switch/availability") == "1");
+    REQUIRE_PUBLISH(server, "test_switch/state", REGWAIT_MSEC);
+
+    server.publish("test_switch/set", "43 44");
+    REQUIRE(server.checkForPublish("test_switch/state", REGWAIT_MSEC) == false);
+
+    server.stop();
+}
 
 static const std::string config_subpath = R"(
 modbus:
@@ -101,13 +136,13 @@ TEST_CASE ("Holding register valid write to subpath topic") {
     server.setModbusRegisterValue("tcptest", 1, 2, modmqttd::RegisterType::HOLDING, 0);
     server.start();
 
-    server.waitForPublish("some/subpath/test_switch/availability", REGWAIT_MSEC);
+    REQUIRE_PUBLISH(server, "some/subpath/test_switch/availability", REGWAIT_MSEC);
     REQUIRE(server.mqttValue("some/subpath/test_switch/availability") == "1");
-    server.waitForPublish("some/subpath/test_switch/state", REGWAIT_MSEC);
+    REQUIRE_PUBLISH(server, "some/subpath/test_switch/state", REGWAIT_MSEC);
 
     server.publish("some/subpath/test_switch/set", "32");
 
-    server.waitForPublish("some/subpath/test_switch/state", REGWAIT_MSEC);
+    REQUIRE_PUBLISH(server, "some/subpath/test_switch/state", REGWAIT_MSEC);
     REQUIRE(server.mqttValue("some/subpath/test_switch/state") == "32");
 
     server.stop();

--- a/unittests/mqtt_remote_call_tests.cpp
+++ b/unittests/mqtt_remote_call_tests.cpp
@@ -1,0 +1,122 @@
+#include <thread>
+#include "catch2/catch.hpp"
+#include "mockedserver.hpp"
+#include "defaults.hpp"
+
+static const std::string config = R"(
+modbus:
+  networks:
+    - name: tcptest
+      address: localhost
+      port: 501
+mqtt:
+  client_id: mqtt_test
+  refresh: 50ms
+  broker:
+    host: localhost
+  objects:
+    - topic: test_call
+      remote_calls:
+        - name: range
+          register: tcptest.1.2
+          register_type: holding
+          size: 2
+      availability: false
+)";
+
+// Better catch2 stack print in case of failure
+#define REQUIRE_PUBLISH(server, topic, timeout) REQUIRE(server.checkForPublish(topic, timeout) == true)
+
+TEST_CASE ("Check no availability published for a rpc object") {
+    MockedModMqttServerThread server(config);
+    server.setModbusRegisterValue("tcptest", 1, 2, modmqttd::RegisterType::HOLDING, 23);
+    server.start();
+    REQUIRE(server.checkForPublish("test_call/availability", std::chrono::milliseconds(REGWAIT_MSEC)) == false);
+    server.stop();
+}
+
+TEST_CASE ("Mqtt binary range write should work if configured") {
+    MockedModMqttServerThread server(config);
+    // Configure range 2-3, set a read/write error guards around
+    server.setModbusRegisterError("tcptest", 1, 1, modmqttd::RegisterType::HOLDING);
+    server.setModbusRegisterValue("tcptest", 1, 2, modmqttd::RegisterType::HOLDING, 42);
+    server.setModbusRegisterError("tcptest", 1, 4, modmqttd::RegisterType::HOLDING);
+    server.start();
+
+    std::this_thread::sleep_for(std::chrono::duration_cast<std::chrono::milliseconds>(REGWAIT_MSEC));
+
+    // In little endian format
+    modmqttd::MqttPublishProps props;
+    props.mCorrelationData = { 1, 2, 3, 4 };
+    props.mResponseTopic = "test_call/ack";
+    server.publish("test_call/range", "43 44", props);
+
+    REQUIRE_PUBLISH(server, "test_call/ack", REGWAIT_MSEC);
+    REQUIRE(server.mqttValueProps("test_call/ack").mCorrelationData == std::vector<uint8_t>({ 1, 2, 3, 4 }));
+
+    // But the writing impacted two registers
+    REQUIRE(server.getModbusRegisterValue("tcptest", 1, 2, modmqttd::RegisterType::HOLDING) == 43);
+    REQUIRE(server.getModbusRegisterValue("tcptest", 1, 3, modmqttd::RegisterType::HOLDING) == 44);
+
+    // Do it again to test range limit, rejected because out of bounds
+    server.publish("test_call/range", "53 54 55", props);
+    std::this_thread::sleep_for(std::chrono::duration_cast<std::chrono::milliseconds>(REGWAIT_MSEC));
+    REQUIRE(server.getModbusRegisterValue("tcptest", 1, 2, modmqttd::RegisterType::HOLDING) == 43);
+    REQUIRE(server.getModbusRegisterValue("tcptest", 1, 3, modmqttd::RegisterType::HOLDING) == 44);
+
+    // Do it again to test negative/invalid values, rejected
+    server.publish("test_call/range", "53 -54", props);
+    std::this_thread::sleep_for(std::chrono::duration_cast<std::chrono::milliseconds>(REGWAIT_MSEC));
+    REQUIRE(server.getModbusRegisterValue("tcptest", 1, 2, modmqttd::RegisterType::HOLDING) == 43);
+    REQUIRE(server.getModbusRegisterValue("tcptest", 1, 3, modmqttd::RegisterType::HOLDING) == 44);
+
+    server.stop();
+}
+
+TEST_CASE ("Mqtt range read via Remote Call should work if configured") {
+    MockedModMqttServerThread server(config);
+    server.setModbusRegisterValue("tcptest", 1, 2, modmqttd::RegisterType::HOLDING, 42);
+    server.setModbusRegisterValue("tcptest", 1, 3, modmqttd::RegisterType::HOLDING, 43);
+    server.start();
+
+    std::this_thread::sleep_for(std::chrono::duration_cast<std::chrono::milliseconds>(REGWAIT_MSEC));
+
+    // In little endian format
+    modmqttd::MqttPublishProps props;
+    props.mCorrelationData = { 1, 2, 3, 4 };
+    props.mResponseTopic = "test_call/read_back";
+    server.publish("test_call/range", { }, props);
+
+    REQUIRE_PUBLISH(server, "test_call/read_back", REGWAIT_MSEC);
+    REQUIRE(server.mqttValue("test_call/read_back") == "42 43");
+    REQUIRE(server.mqttValueProps("test_call/read_back").mCorrelationData == std::vector<uint8_t>({ 1, 2, 3, 4 }));
+
+    // Check that availability and polling are not happening. Wait at least the global configured
+    // refresh time
+    std::this_thread::sleep_for(std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::milliseconds(100)));
+    REQUIRE(server.getModbusRegisterReadCount("tcptest", 1, 2, modmqttd::RegisterType::HOLDING) == 1);
+    REQUIRE(server.getModbusRegisterReadCount("tcptest", 1, 3, modmqttd::RegisterType::HOLDING) == 1);
+
+    // Test potential issues around int16 negative values
+    // New correlation data
+    server.setModbusRegisterValue("tcptest", 1, 3, modmqttd::RegisterType::HOLDING, 65000);
+    props.mCorrelationData = { 1, 2, 3, 5 };
+    server.publish("test_call/range", { }, props);
+    REQUIRE_PUBLISH(server, "test_call/read_back", REGWAIT_MSEC);
+    REQUIRE(server.mqttValue("test_call/read_back") == "42 65000");
+    REQUIRE(server.mqttValueProps("test_call/read_back").mCorrelationData == std::vector<uint8_t>({ 1, 2, 3, 5 }));
+
+    // Test error due to disconnections
+    server.disconnectModbusSlave("tcptest", 1);
+
+    props.mCorrelationData = { 11, 12 };
+    props.mResponseTopic = "test_call/read_back";
+    server.publish("test_call/range", { }, props);
+
+    REQUIRE_PUBLISH(server, "test_call/read_back", REGWAIT_MSEC);
+    REQUIRE(server.mqttValue("test_call/read_back") == "libmodbus: read fn 2 failed: Input/output error");
+    REQUIRE(server.mqttValueProps("test_call/read_back").mCorrelationData == std::vector<uint8_t>({ 11, 12 }));
+
+    server.stop();
+}
+

--- a/unittests/mqtt_unnamed_list_tests.cpp
+++ b/unittests/mqtt_unnamed_list_tests.cpp
@@ -27,7 +27,7 @@ TEST_CASE ("Unnamed state list without register value should not be available") 
     MockedModMqttServerThread server(config);
     server.setModbusRegisterValue("tcptest", 1, 2, modmqttd::RegisterType::INPUT, 1);
     server.setModbusRegisterValue("tcptest", 1, 3, modmqttd::RegisterType::INPUT, 7);
-    server.setModbusRegisterReadError("tcptest", 1, 3, modmqttd::RegisterType::INPUT);
+    server.setModbusRegisterError("tcptest", 1, 3, modmqttd::RegisterType::INPUT);
 
     server.start();
 


### PR DESCRIPTION
The current gateway's declarative support for aggregating, converting and publishing register values as MQTT topic is great. However, for performance reason, in some situations it can be more useful to access Modbus registers on-demand.
Some examples:
- write calibration data
- access logged data
- use external complex conversion algorithms to convert values (e.g. the binary data of the BMP180 sensor)

The idea is then to leverage the [MQTT RPC protocol](https://www.hivemq.com/blog/mqtt5-essentials-part9-request-response-pattern), exposing new object type like this:

```yaml
modbus:
  networks:
    - name: tcptest
mqtt:
  objects:
    - topic: test_call
      remote_calls:
        - name: range
          register: tcptest.1.1024
          register_type: holding
          size: 16  # Read/write the [1024-1039] address range in one go
      availability: false
```
 
The PR doesn't cope with the converters, since the current converter infrastructure requires major overhaul to support range of registers.

The string format of the topic data is in plain `istream` bank-separated format (e.g. `23 45 67`). I'm unsure if the JSON format should be used instead.
New PR will probably follow to support full binary data, and to specify data endianness (at the moment the host machine endianness is used by `libmodbus` implementation). However, I'm not sure how to extend the support of such new "binary" format to state objects too, due to the converters support on top. Any suggestion on how to proceed are welcome!

Due to the amount of changes required, I've tried to arrange the changes in "atomic" commits, that adds one feature at a time.

All the proposed changes are compliant to the current LICENSE.

Thanks! L