### PR TITLE
Add support for 32-bit numbers in different byte orders to exprtk converter

### DIFF
--- a/README.md
+++ b/README.md
@@ -545,17 +545,17 @@ Register values are defined as R0..Rn variables.
       - [exprtk expression](http://www.partow.net/programming/exprtk/) with Rx as register variables (required)
       - precision (optional)
 
-    The following custom functions for 32-bit numbers are supported in the expression:
-      - `int32be()`:   signed integer in big-endian byte order
-      - `int32le()`:   signed integer in little-endian byte order
-      - `uint32be()`:  unsigned integer in big-endian byte order
-      - `uint32le()`:  unsigned integer in little-endian byte order
-      - `flt32be()`:   float in big-endian byte order
-      - `flt32le()`:   float in little-endian byte order
-      - `flt32abcd()`: float in byte order ABCD
-      - `flt32badc()`: float in byte order BADC
-      - `flt32cdab()`: float in byte order CDAB
-      - `flt32dcba()`: float in byte order DCBA
+    The following custom functions for 32-bit numbers are supported in the expression.
+    _ABCD_ means a number composed of the byte array `[A, B, C, D]`,
+    where _A_ is the most significant byte (MSB) and _D_ is the least-significant byte (LSB).
+      - `int32(r1, r2)`:   Cast to signed integer _ABCD_ from `r1` == _AB_ and `r2` == _CD_.
+      - `int32(r2, r1)`:   Cast to signed integer _ABCD_ from `r1` == _CD_ and `r2` == _AB_.
+      - `uint32(r1, r2)`:  Cast to unsigned integer _ABCD_ from `r1` == _AB_ and `r2` == _CD_.
+      - `uint32(r2, r1)`:  Cast to unsigned integer _ABCD_ from `r1` == _CD_ and `r2` == _AB_.
+      - `flt32(r1, r2)`:   Cast to float _ABCD_ from `r1` == _AB_ and `r2` == _CD_.
+      - `flt32(r2, r1)`:   Cast to float _ABCD_ from `r1` == _CD_ and `r2` == _AB_.
+      - `flt32be(r1, r2)`: Cast to float _ABCD_ from `r1` == _BA_ and `r2` == _DC_.
+      - `flt32be(r2, r1)`: Cast to float _ABCD_ from `r1` == _DC_ and `r2` == _BA_.
 
 #### Examples
 Division of two registers with precision 3:
@@ -572,7 +572,7 @@ Division of two registers with precision 3:
             register_type: input
 ```
 
-Reading the state of a 32-bit float value spanning two registers with precision 3:
+Reading the state of a 32-bit float value (byte order `ABCD`) spanning two registers (R0 = `BA`, R1 = `DC`) with precision 3:
 ```
   objects:
     - topic: test_state

--- a/README.md
+++ b/README.md
@@ -545,7 +545,20 @@ Register values are defined as R0..Rn variables.
       - [exprtk expression](http://www.partow.net/programming/exprtk/) with Rx as register variables (required)
       - precision (optional)
 
-Here is an example dividing two registers with precision=3
+    The following custom functions for 32-bit numbers are supported in the expression:
+      - `int32be()`:   signed integer in big-endian byte order
+      - `int32le()`:   signed integer in little-endian byte order
+      - `uint32be()`:  unsigned integer in big-endian byte order
+      - `uint32le()`:  unsigned integer in little-endian byte order
+      - `flt32be()`:   float in big-endian byte order
+      - `flt32le()`:   float in little-endian byte order
+      - `flt32abcd()`: float in byte order ABCD
+      - `flt32badc()`: float in byte order BADC
+      - `flt32cdab()`: float in byte order CDAB
+      - `flt32dcba()`: float in byte order DCBA
+
+#### Examples
+Division of two registers with precision 3:
 
 ```
   objects:
@@ -558,6 +571,20 @@ Here is an example dividing two registers with precision=3
           - register: tcptest.1.3
             register_type: input
 ```
+
+Reading the state of a 32-bit float value spanning two registers with precision 3:
+```
+  objects:
+    - topic: test_state
+      state:
+        converter: expr.evaluate("flt32be(R0, R1)", 3)
+        registers:
+          - register: tcptest.1.2
+            register_type: input
+          - register: tcptest.1.3
+            register_type: input
+```
+
 
 
 ### Adding custom converters

--- a/exprconv/expr.hpp
+++ b/exprconv/expr.hpp
@@ -30,16 +30,10 @@ class ExprtkConverter : public DataConverter {
         }
 
         virtual void setArgs(const std::vector<std::string>& args) {
-            mSymbolTable.add_function("int32be",   int32be);
-            mSymbolTable.add_function("int32le",   int32le);
-            mSymbolTable.add_function("uint32be",  uint32be);
-            mSymbolTable.add_function("uint32le",  uint32le);
-            mSymbolTable.add_function("flt32be",   flt32be);
-            mSymbolTable.add_function("flt32le",   flt32le);
-            mSymbolTable.add_function("flt32abcd", flt32abcd);
-            mSymbolTable.add_function("flt32badc", flt32badc);
-            mSymbolTable.add_function("flt32cdab", flt32cdab);
-            mSymbolTable.add_function("flt32dcba", flt32dcba);
+            mSymbolTable.add_function("int32",   int32);
+            mSymbolTable.add_function("uint32",  uint32);
+            mSymbolTable.add_function("flt32",   flt32);
+            mSymbolTable.add_function("flt32be", flt32be);
             mSymbolTable.add_constants();
 
             char buf[8];
@@ -69,43 +63,19 @@ class ExprtkConverter : public DataConverter {
             return dummy / divider;
         }
 
-        static double int32be(const double register1, const double register2) {
-            return ConverterTools::toNumber<int32_t>(register1, register2);
+        static double int32(const double highRegister, const double lowRegister) {
+            return ConverterTools::toNumber<int32_t>(highRegister, lowRegister, true);
         }
 
-        static double int32le(const double register1, const double register2) {
-            return ConverterTools::toNumber<int32_t>(register1, register2, true);
+        static double uint32(const double highRegister, const double lowRegister) {
+            return ConverterTools::toNumber<uint32_t>(highRegister, lowRegister, true);
         }
 
-        static double uint32be(const double register1, const double register2) {
-            return ConverterTools::toNumber<uint32_t>(register1, register2);
+        static double flt32(const double highRegister, const double lowRegister) {
+            return ConverterTools::toNumber<float>(highRegister, lowRegister, true);
         }
 
-        static double uint32le(const double register1, const double register2) {
-            return ConverterTools::toNumber<uint32_t>(register1, register2, true);
-        }
-
-        static double flt32be(const double register1, const double register2) {
-            return ConverterTools::toNumber<float>(register1, register2);
-        }
-
-        static double flt32le(const double register1, const double register2) {
-            return ConverterTools::toNumber<float>(register1, register2, true);
-        }
-
-        static double flt32abcd(const double register1, const double register2) {
-            return ConverterTools::toNumber<float>(register1, register2);
-        }
-
-        static double flt32badc(const double register1, const double register2) {
-            return ConverterTools::toNumber<float>(register1, register2, true);
-        }
-
-        static double flt32cdab(const double register1, const double register2) {
-            return ConverterTools::toNumber<float>(register2, register1);
-        }
-
-        static double flt32dcba(const double register1, const double register2) {
-            return ConverterTools::toNumber<float>(register2, register1, true);
+        static double flt32be(const double highRegister, const double lowRegister) {
+            return ConverterTools::toNumber<float>(highRegister, lowRegister);
         }
 };

--- a/exprconv/expr.hpp
+++ b/exprconv/expr.hpp
@@ -30,6 +30,16 @@ class ExprtkConverter : public DataConverter {
         }
 
         virtual void setArgs(const std::vector<std::string>& args) {
+            mSymbolTable.add_function("int32be",   int32be);
+            mSymbolTable.add_function("int32le",   int32le);
+            mSymbolTable.add_function("uint32be",  uint32be);
+            mSymbolTable.add_function("uint32le",  uint32le);
+            mSymbolTable.add_function("flt32be",   flt32be);
+            mSymbolTable.add_function("flt32le",   flt32le);
+            mSymbolTable.add_function("flt32abcd", flt32abcd);
+            mSymbolTable.add_function("flt32badc", flt32badc);
+            mSymbolTable.add_function("flt32cdab", flt32cdab);
+            mSymbolTable.add_function("flt32dcba", flt32dcba);
             mSymbolTable.add_constants();
 
             char buf[8];
@@ -57,5 +67,45 @@ class ExprtkConverter : public DataConverter {
             double divider = pow(10, decimal_digits);
             int dummy = (int)(val * divider);
             return dummy / divider;
+        }
+
+        static double int32be(const double register1, const double register2) {
+            return ConverterTools::toNumber<int32_t>(register1, register2);
+        }
+
+        static double int32le(const double register1, const double register2) {
+            return ConverterTools::toNumber<int32_t>(register1, register2, true);
+        }
+
+        static double uint32be(const double register1, const double register2) {
+            return ConverterTools::toNumber<uint32_t>(register1, register2);
+        }
+
+        static double uint32le(const double register1, const double register2) {
+            return ConverterTools::toNumber<uint32_t>(register1, register2, true);
+        }
+
+        static double flt32be(const double register1, const double register2) {
+            return ConverterTools::toNumber<float>(register1, register2);
+        }
+
+        static double flt32le(const double register1, const double register2) {
+            return ConverterTools::toNumber<float>(register1, register2, true);
+        }
+
+        static double flt32abcd(const double register1, const double register2) {
+            return ConverterTools::toNumber<float>(register1, register2);
+        }
+
+        static double flt32badc(const double register1, const double register2) {
+            return ConverterTools::toNumber<float>(register1, register2, true);
+        }
+
+        static double flt32cdab(const double register1, const double register2) {
+            return ConverterTools::toNumber<float>(register2, register1);
+        }
+
+        static double flt32dcba(const double register1, const double register2) {
+            return ConverterTools::toNumber<float>(register2, register1, true);
         }
 };

--- a/libmodmqttconv/converter.hpp
+++ b/libmodmqttconv/converter.hpp
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <algorithm>
 #include <cstdint>
 #include <stdexcept>
 #include <string>
@@ -114,8 +113,9 @@ class ConverterTools {
          * @param value A list of registers
          */
         static void swapByteOrder(std::vector<uint16_t>& registers) {
-            uint16_t (*swapByteOrderFunction)(uint16_t) = &swapByteOrder;
-            std::transform(registers.begin(), registers.end(), registers.begin(), swapByteOrderFunction);
+            for (size_t i = 0; i < registers.size(); i++) {
+                registers[i] = swapByteOrder(registers[i]);
+            }
         }
 
         /**

--- a/libmodmqttconv/converter.hpp
+++ b/libmodmqttconv/converter.hpp
@@ -119,13 +119,13 @@ class ConverterTools {
         }
 
         /**
-         * Converts two registers (0xAB and 0xCD) to a 32-bit number (0xABCD).
+         * Converts two registers (e.g. r1=0xA1B2 and r2=0xC3D4) to one 32-bit number (e.g. n=0xA1B2C3D4).
          *
          * @tparam T Type of the 32-bit number
-         * @param highRegister A register containing the most significant bytes A and B
-         * @param lowRegister  A register containing the least significant bytes C and D
-         * @param swapBytes    If set to true, the low and high byte of both registers are swapped
-         *                     (number == 0xBADC)
+         * @param highRegister A register containing the most significant bytes (e.g. 0xA1B2)
+         * @param lowRegister  A register containing the least significant bytes (e.g. 0xC3D4)
+         * @param swapBytes    If set to true, the high and low byte of both registers are swapped
+         *                     (e.g. n=0xB2A1D4C3).
          * @return A number containing the bytes of both registers
          */
         template <typename T>

--- a/unittests/exprconv_tests.cpp
+++ b/unittests/exprconv_tests.cpp
@@ -5,48 +5,32 @@
 
 #ifdef HAVE_EXPRTK
 
-TEST_CASE ("Exprtk converter test") {
+TEST_CASE ("A number should be converted by exprtk") {
     std::string stdconv_path = "../exprconv/exprconv.so";
-
     boost::shared_ptr<ConverterPlugin> plugin = boost_dll_import<ConverterPlugin>(
         stdconv_path,
         "converter_plugin",
         boost::dll::load_mode::append_decorations
     );
-
     std::shared_ptr<DataConverter> conv(plugin->getConverter("evaluate"));
-    std::vector<std::string> args = {
-        "R0 * 2"
-    };
-    conv->setArgs(args);
 
-    ModbusRegisters data;
-    data.appendValue(10);
-    MqttValue ret = conv->toMqtt(data);
+    SECTION("when precision is not set") {
+        conv->setArgs({"R0 * 2"});
+        const ModbusRegisters input(10);
 
-    REQUIRE(ret.getString() == "20");
-}
+        MqttValue output = conv->toMqtt(input);
 
-TEST_CASE ("Exprtk converter test with precission") {
-    std::string stdconv_path = "../exprconv/exprconv.so";
+        REQUIRE(output.getString() == "20");
+    }
 
-    boost::shared_ptr<ConverterPlugin> plugin = boost_dll_import<ConverterPlugin>(
-        stdconv_path,
-        "converter_plugin",
-        boost::dll::load_mode::append_decorations
-    );
+    SECTION("when precision is set") {
+        conv->setArgs({"R0 / 3", "3"});
+        const ModbusRegisters input(10);
 
-    std::shared_ptr<DataConverter> conv(plugin->getConverter("evaluate"));
-    std::vector<std::string> args = {
-        "R0 / 3", "3"
-    };
-    conv->setArgs(args);
+        MqttValue output = conv->toMqtt(input);
 
-    ModbusRegisters data;
-    data.appendValue(10);
-    MqttValue ret = conv->toMqtt(data);
-
-    REQUIRE(ret.getString() == "3.333");
+        REQUIRE(output.getString() == "3.333");
+    }
 }
 
 
@@ -59,27 +43,69 @@ TEST_CASE("A 32-bit number should be converted by exprtk") {
     );
     std::shared_ptr<DataConverter> conv(plugin->getConverter("evaluate"));
 
+    SECTION("when two registers contain a signed integer") {
+        conv->setArgs({"int32(R0, R1)"});
+        const ModbusRegisters input({0xdcfe, 0x98ba});
+        const int32_t expected = 0xfedcba98;
+
+        MqttValue output = conv->toMqtt(input);
+
+        REQUIRE(output.getDouble() == expected);
+        REQUIRE(output.getString() == "-19088744");
+    }
+
+    SECTION("when two registers contain an unsigned integer") {
+        conv->setArgs({"uint32(R0, R1)"});
+        const ModbusRegisters input({0xdcfe, 0x98ba});
+
+        MqttValue output = conv->toMqtt(input);
+
+        REQUIRE(output.getDouble() == 0xfedcba98);
+        REQUIRE(output.getString() == "4275878552");
+    }
+
     SECTION("when two registers contain a float") {
         const float expected = -123.456f; // 0xc2f6e979 in IEEE 754 hex representation
+        const std::string expectedString = "-123.456001";
 
-        SECTION("and byte order is big-endian") {
+        SECTION("and byte order is ABCD") {
             conv->setArgs({"flt32be(R0, R1)"});
             const ModbusRegisters input({0xc2f6, 0xe979});
 
             MqttValue output = conv->toMqtt(input);
 
             REQUIRE(output.getDouble() == expected);
-            REQUIRE(output.getString() == "-123.456001");
+            REQUIRE(output.getString() == expectedString);
         }
 
-        SECTION("and byte order is little-endian") {
-            conv->setArgs({"flt32le(R0, R1)"});
+        SECTION("and byte order is CDAB") {
+            conv->setArgs({"flt32be(R1, R0)"});
+            const ModbusRegisters input({0xe979, 0xc2f6});
+
+            MqttValue output = conv->toMqtt(input);
+
+            REQUIRE(output.getDouble() == expected);
+            REQUIRE(output.getString() == expectedString);
+        }
+
+        SECTION("and byte order is BADC") {
+            conv->setArgs({"flt32(R0, R1)"});
             const ModbusRegisters input({0xf6c2, 0x79e9});
 
             MqttValue output = conv->toMqtt(input);
 
             REQUIRE(output.getDouble() == expected);
-            REQUIRE(output.getString() == "-123.456001");
+            REQUIRE(output.getString() == expectedString);
+        }
+
+        SECTION("and byte order is DCBA") {
+            conv->setArgs({"flt32(R1, R0)"});
+            const ModbusRegisters input({0x79e9, 0xf6c2});
+
+            MqttValue output = conv->toMqtt(input);
+
+            REQUIRE(output.getDouble() == expected);
+            REQUIRE(output.getString() == expectedString);
         }
 
         SECTION("and precision is set") {
@@ -90,104 +116,6 @@ TEST_CASE("A 32-bit number should be converted by exprtk") {
 
             REQUIRE(output.getString() == "-123.456");
         }
-    }
-
-    SECTION("when two registers contain a signed integer") {
-        const int32_t expected = 0xfedcba98;
-        const std::string expectedString = "-19088744";
-
-        SECTION("and byte order is big-endian") {
-            conv->setArgs({"int32be(R0, R1)"});
-            const ModbusRegisters input({0xfedc, 0xba98});
-
-            MqttValue output = conv->toMqtt(input);
-
-            REQUIRE(output.getDouble() == expected);
-            REQUIRE(output.getString() == expectedString);
-        }
-
-        SECTION("and byte order is little-endian") {
-            conv->setArgs({"int32le(R0, R1)"});
-            const ModbusRegisters input({0xdcfe, 0x98ba});
-
-            MqttValue output = conv->toMqtt(input);
-
-            REQUIRE(output.getDouble() == expected);
-            REQUIRE(output.getString() == expectedString);
-        }
-    }
-
-    SECTION("when two registers contain an unsigned integer") {
-        const uint32_t expected = 0xfedcba98;
-        std::string expectedString = "4275878552";
-
-        SECTION("and byte order is big-endian") {
-            conv->setArgs({"uint32be(R0, R1)"});
-            const ModbusRegisters input({0xfedc, 0xba98});
-
-            MqttValue output = conv->toMqtt(input);
-
-            REQUIRE(output.getDouble() == expected);
-            REQUIRE(output.getString() == expectedString);
-        }
-
-        SECTION("and byte order is little-endian") {
-            conv->setArgs({"uint32le(R0, R1)"});
-            const ModbusRegisters input({0xdcfe, 0x98ba});
-
-            MqttValue output = conv->toMqtt(input);
-
-            REQUIRE(output.getDouble() == expected);
-            REQUIRE(output.getString() == expectedString);
-        }
-    }
-}
-
-TEST_CASE("A float value should be converted by exprtk") {
-    std::string stdconv_path = "../exprconv/exprconv.so";
-
-    boost::shared_ptr<ConverterPlugin> plugin = boost_dll_import<ConverterPlugin>(
-        stdconv_path,
-        "converter_plugin",
-        boost::dll::load_mode::append_decorations
-    );
-    std::shared_ptr<DataConverter> conv(plugin->getConverter("evaluate"));
-    const float expected = -123.456f; // 0xc2f6e979 in IEEE 754 hex representation
-
-    SECTION("when two registers contain the bytes in order ABCD") {
-        conv->setArgs({"flt32abcd(R0, R1)"});
-        const ModbusRegisters input({0xc2f6, 0xe979});
-
-        MqttValue output = conv->toMqtt(input);
-
-        REQUIRE(output.getDouble() == expected);
-    }
-
-    SECTION("when two registers contain the bytes in order BADC") {
-        conv->setArgs({"flt32badc(R0, R1)"});
-        const ModbusRegisters input({0xf6c2, 0x79e9});
-
-        MqttValue output = conv->toMqtt(input);
-
-        REQUIRE(output.getDouble() == expected);
-    }
-
-    SECTION("when two registers contain the bytes in order CDAB") {
-        conv->setArgs({"flt32cdab(R0, R1)"});
-        const ModbusRegisters input({0xe979, 0xc2f6});
-
-        MqttValue output = conv->toMqtt(input);
-
-        REQUIRE(output.getDouble() == expected);
-    }
-
-    SECTION("when two registers contain the bytes in order DCBA") {
-        conv->setArgs({"flt32dcba(R0, R1)"});
-        const ModbusRegisters input({0x79e9, 0xf6c2});
-
-        MqttValue output = conv->toMqtt(input);
-
-        REQUIRE(output.getDouble() == expected);
     }
 }
 

--- a/unittests/exprconv_tests.cpp
+++ b/unittests/exprconv_tests.cpp
@@ -1,8 +1,7 @@
-#include <libmodmqttsrv/config.hpp>
-#include "catch2/catch.hpp"
 #include <boost/dll/import.hpp>
-
+#include <catch2/catch.hpp>
 #include "libmodmqttconv/converterplugin.hpp"
+#include "libmodmqttsrv/config.hpp"
 
 #ifdef HAVE_EXPRTK
 
@@ -50,5 +49,146 @@ TEST_CASE ("Exprtk converter test with precission") {
     REQUIRE(ret.getString() == "3.333");
 }
 
+
+TEST_CASE("A 32-bit number should be converted by exprtk") {
+    std::string stdconv_path = "../exprconv/exprconv.so";
+    boost::shared_ptr<ConverterPlugin> plugin = boost_dll_import<ConverterPlugin>(
+        stdconv_path,
+        "converter_plugin",
+        boost::dll::load_mode::append_decorations
+    );
+    std::shared_ptr<DataConverter> conv(plugin->getConverter("evaluate"));
+
+    SECTION("when two registers contain a float") {
+        const float expected = -123.456f; // 0xc2f6e979 in IEEE 754 hex representation
+
+        SECTION("and byte order is big-endian") {
+            conv->setArgs({"flt32be(R0, R1)"});
+            const ModbusRegisters input({0xc2f6, 0xe979});
+
+            MqttValue output = conv->toMqtt(input);
+
+            REQUIRE(output.getDouble() == expected);
+            REQUIRE(output.getString() == "-123.456001");
+        }
+
+        SECTION("and byte order is little-endian") {
+            conv->setArgs({"flt32le(R0, R1)"});
+            const ModbusRegisters input({0xf6c2, 0x79e9});
+
+            MqttValue output = conv->toMqtt(input);
+
+            REQUIRE(output.getDouble() == expected);
+            REQUIRE(output.getString() == "-123.456001");
+        }
+
+        SECTION("and precision is set") {
+            conv->setArgs({"flt32be(R0, R1)", "3"});
+            const ModbusRegisters input({0xc2f6, 0xe979});
+
+            MqttValue output = conv->toMqtt(input);
+
+            REQUIRE(output.getString() == "-123.456");
+        }
+    }
+
+    SECTION("when two registers contain a signed integer") {
+        const int32_t expected = 0xfedcba98;
+        const std::string expectedString = "-19088744";
+
+        SECTION("and byte order is big-endian") {
+            conv->setArgs({"int32be(R0, R1)"});
+            const ModbusRegisters input({0xfedc, 0xba98});
+
+            MqttValue output = conv->toMqtt(input);
+
+            REQUIRE(output.getDouble() == expected);
+            REQUIRE(output.getString() == expectedString);
+        }
+
+        SECTION("and byte order is little-endian") {
+            conv->setArgs({"int32le(R0, R1)"});
+            const ModbusRegisters input({0xdcfe, 0x98ba});
+
+            MqttValue output = conv->toMqtt(input);
+
+            REQUIRE(output.getDouble() == expected);
+            REQUIRE(output.getString() == expectedString);
+        }
+    }
+
+    SECTION("when two registers contain an unsigned integer") {
+        const uint32_t expected = 0xfedcba98;
+        std::string expectedString = "4275878552";
+
+        SECTION("and byte order is big-endian") {
+            conv->setArgs({"uint32be(R0, R1)"});
+            const ModbusRegisters input({0xfedc, 0xba98});
+
+            MqttValue output = conv->toMqtt(input);
+
+            REQUIRE(output.getDouble() == expected);
+            REQUIRE(output.getString() == expectedString);
+        }
+
+        SECTION("and byte order is little-endian") {
+            conv->setArgs({"uint32le(R0, R1)"});
+            const ModbusRegisters input({0xdcfe, 0x98ba});
+
+            MqttValue output = conv->toMqtt(input);
+
+            REQUIRE(output.getDouble() == expected);
+            REQUIRE(output.getString() == expectedString);
+        }
+    }
+}
+
+TEST_CASE("A float value should be converted by exprtk") {
+    std::string stdconv_path = "../exprconv/exprconv.so";
+
+    boost::shared_ptr<ConverterPlugin> plugin = boost_dll_import<ConverterPlugin>(
+        stdconv_path,
+        "converter_plugin",
+        boost::dll::load_mode::append_decorations
+    );
+    std::shared_ptr<DataConverter> conv(plugin->getConverter("evaluate"));
+    const float expected = -123.456f; // 0xc2f6e979 in IEEE 754 hex representation
+
+    SECTION("when two registers contain the bytes in order ABCD") {
+        conv->setArgs({"flt32abcd(R0, R1)"});
+        const ModbusRegisters input({0xc2f6, 0xe979});
+
+        MqttValue output = conv->toMqtt(input);
+
+        REQUIRE(output.getDouble() == expected);
+    }
+
+    SECTION("when two registers contain the bytes in order BADC") {
+        conv->setArgs({"flt32badc(R0, R1)"});
+        const ModbusRegisters input({0xf6c2, 0x79e9});
+
+        MqttValue output = conv->toMqtt(input);
+
+        REQUIRE(output.getDouble() == expected);
+    }
+
+    SECTION("when two registers contain the bytes in order CDAB") {
+        conv->setArgs({"flt32cdab(R0, R1)"});
+        const ModbusRegisters input({0xe979, 0xc2f6});
+
+        MqttValue output = conv->toMqtt(input);
+
+        REQUIRE(output.getDouble() == expected);
+    }
+
+    SECTION("when two registers contain the bytes in order DCBA") {
+        conv->setArgs({"flt32dcba(R0, R1)"});
+        const ModbusRegisters input({0x79e9, 0xf6c2});
+
+        MqttValue output = conv->toMqtt(input);
+
+        REQUIRE(output.getDouble() == expected);
+    }
+}
 
 #endif


### PR DESCRIPTION
This pull request adds several functions to exprtk to handle 32-bit number types (float, int32, uint32) and to cope with different byte orders ([origin discussion](https://github.com/BlackZork/mqmgateway/pull/21#issuecomment-1636740436)).