### PR TITLE
Fix build on Alpine Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,7 +256,7 @@ A list of topics where modbus values are published to MQTT broker and subscribed
 
   * **converter** (optional)
 
-    The name of function that should be called to convert mqtt value to u_int16 value. Format of function name is `plugin name.function name`. See converters for details. 
+    The name of function that should be called to convert mqtt value to uint16_t value. Format of function name is `plugin name.function name`. See converters for details. 
 
   Example of MQTT command topic declaration:
 
@@ -279,9 +279,9 @@ A list of topics where modbus values are published to MQTT broker and subscribed
 
   | Value type | Default output |
   | --- | --- |
-  | single register | u_int16 register data as string |
-  | unnamed list | JSON array with u_int16 register data as string |
-  | named list | JSON map with values as u_int16 register data as string |
+  | single register | uint16_t register data as string |
+  | unnamed list | JSON array with uint16_t register data as string |
+  | named list | JSON map with values as uint16_t register data as string |
 
   It is also possible to combine and output an unnamed list of registers as a single value using converter. See converters section for details.
 
@@ -352,7 +352,7 @@ A list of topics where modbus values are published to MQTT broker and subscribed
 
   * **converter** (optional)
 
-    The name of function that should be called to convert register u_int16 value to MQTT UTF-8 value. Format of function name is `plugin_name.function_name`. See converters for details. 
+    The name of function that should be called to convert register uint16_t value to MQTT UTF-8 value. Format of function name is `plugin_name.function_name`. See converters for details. 
 
   The following examples show how to combine *name*, *register*, *register_type*, and *converter* to output different state values:
 

--- a/libmodmqttsrv/modbus_messages.hpp
+++ b/libmodmqttsrv/modbus_messages.hpp
@@ -35,7 +35,7 @@ class MsgRegisterValues : public MsgRegisterMessageBase {
         MsgRegisterValues(int slaveId, RegisterType regType, int registerNumber, const ModbusRegisters& registers)
             : MsgRegisterMessageBase(slaveId, regType, registerNumber, registers.getCount()),
               mRegisters(registers) {}
-        MsgRegisterValues(int slaveId, RegisterType regType, int registerNumber, const std::vector<u_int16_t>& registers)
+        MsgRegisterValues(int slaveId, RegisterType regType, int registerNumber, const std::vector<uint16_t>& registers)
             : MsgRegisterMessageBase(slaveId, regType, registerNumber, registers.size()),
               mRegisters(registers) {}
 


### PR DESCRIPTION
This PR fixes a leftover `u_int16_t` that breaks the build on Alpine Linux (see #7).