### PR TITLE
Fix: support publish for uint32 values

### DIFF
--- a/libmodmqttsrv/mqttobject.cpp
+++ b/libmodmqttsrv/mqttobject.cpp
@@ -159,6 +159,9 @@ createConvertedValue(
         case MqttValue::SourceType::BINARY:
             writer.String(static_cast<const char*>(value.getBinaryPtr()), value.getBinarySize());
             break;
+        case MqttValue::SourceType::INT64:
+            writer.Int64(value.getInt64());
+            break;
     }
 }
 


### PR DESCRIPTION
Without this patch, all values converted by `std.uint32()` are published as `null` via MQTT.