### PR TITLE
Allow log level configuration for tests

### DIFF
--- a/unittests/main.cpp
+++ b/unittests/main.cpp
@@ -5,7 +5,11 @@
 
 int main( int argc, char* argv[] ) {
 
-  modmqttd::Log::init_logging(modmqttd::Log::severity::debug);
+  modmqttd::Log::severity loglevel = modmqttd::Log::severity::debug;
+  if (const char* env_p = std::getenv("MQM_TEST_LOGLEVEL")) {
+      loglevel = static_cast<modmqttd::Log::severity>(std::atoi(env_p) - 1);
+  }
+  modmqttd::Log::init_logging(loglevel);
 
   int result = Catch::Session().run( argc, argv );
 

--- a/unittests/mqtt_unnamed_scalar_expr_tests.cpp
+++ b/unittests/mqtt_unnamed_scalar_expr_tests.cpp
@@ -4,7 +4,6 @@
 
 static const std::string config = R"(
 modmqttd:
-  loglevel: 5
   converter_search_path:
     - build/exprconv
   converter_plugins:


### PR DESCRIPTION
This PR adds the ability to configure the log level for tests using the env variable `MQM_TEST_LOGLEVEL`.