### PR TITLE
Fix test failures on i386 platform related to floating point issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -454,12 +454,12 @@ MQMGateway contains *std* library with basic converters ready to use:
     Usage: state, command
 
     Arguments:
-      - divider (required)
+      - divisor (required)
       - precision (optional)
       - low_first (optional)
 
 
-    Divides modbus value by divider and rounds to (precision) digits after the decimal.
+    Divides modbus value by divisor and rounds to (precision) digits after the decimal.
     Supports int16 in single register and int32 value in two registers.
     For int32 mode the first modbus register holds higher byte, the second holds lower byte if 'low first' is not passed.
     With 'low_first' argument the first modbus register holds lower byte, the second holds higher byte.

--- a/exprconv/expr.hpp
+++ b/exprconv/expr.hpp
@@ -25,7 +25,7 @@ class ExprtkConverter : public DataConverter {
                 return MqttValue::fromInt(ret);
 
             if (precision != -1)
-                ret = round(ret, precision);
+                ret = ConverterTools::round(ret, precision);
             return MqttValue::fromDouble(ret);
         }
 
@@ -57,12 +57,6 @@ class ExprtkConverter : public DataConverter {
         exprtk::expression<double> mExpression;
         mutable std::vector<double> mValues;
         int precision = -1;
-
-        static double round(double val, int decimal_digits) {
-            double divider = pow(10, decimal_digits);
-            int dummy = (int)(val * divider);
-            return dummy / divider;
-        }
 
         static double int32(const double highRegister, const double lowRegister) {
             return ConverterTools::toNumber<int32_t>(highRegister, lowRegister, true);

--- a/exprconv/expr.hpp
+++ b/exprconv/expr.hpp
@@ -21,12 +21,10 @@ class ExprtkConverter : public DataConverter {
 
             double ret = mExpression.value();
 
-            if (precision == 0)
+            if (mPrecision == 0)
                 return MqttValue::fromInt(ret);
 
-            if (precision != -1)
-                ret = ConverterTools::round(ret, precision);
-            return MqttValue::fromDouble(ret);
+            return MqttValue::fromDouble(ret, mPrecision);
         }
 
         virtual void setArgs(const std::vector<std::string>& args) {
@@ -47,7 +45,7 @@ class ExprtkConverter : public DataConverter {
             mParser.compile(ConverterTools::getArg(0, args), mExpression);
 
             if (args.size() == 2)
-                precision = ConverterTools::getIntArg(1, args);
+                mPrecision = ConverterTools::getIntArg(1, args);
         }
 
         virtual ~ExprtkConverter() {}
@@ -56,7 +54,7 @@ class ExprtkConverter : public DataConverter {
         exprtk::parser<double> mParser;
         exprtk::expression<double> mExpression;
         mutable std::vector<double> mValues;
-        int precision = -1;
+        int mPrecision = MqttValue::DEFAULT_DOUBLE_PRECISION;
 
         static double int32(const double highRegister, const double lowRegister) {
             return ConverterTools::toNumber<int32_t>(highRegister, lowRegister, true);

--- a/exprconv/expr.hpp
+++ b/exprconv/expr.hpp
@@ -81,6 +81,6 @@ class ExprtkConverter : public DataConverter {
         }
 
         static double int16(const double regValue) {
-            return int16_t(regValue);
+            return ConverterTools::toNumber<int16_t>(0, regValue);
         }
 };

--- a/exprconv/expr.hpp
+++ b/exprconv/expr.hpp
@@ -54,7 +54,7 @@ class ExprtkConverter : public DataConverter {
         exprtk::parser<double> mParser;
         exprtk::expression<double> mExpression;
         mutable std::vector<double> mValues;
-        int mPrecision = MqttValue::DEFAULT_DOUBLE_PRECISION;
+        int mPrecision = -1;
 
         static double int32(const double highRegister, const double lowRegister) {
             return ConverterTools::toNumber<int32_t>(highRegister, lowRegister, true);

--- a/libmodmqttconv/converter.hpp
+++ b/libmodmqttconv/converter.hpp
@@ -148,18 +148,6 @@ class ConverterTools {
             int32_t value = registersToInt32(registers, false);
             return *reinterpret_cast<T*>(&value);
         }
-
-        /**
-         * round double value to decimal_digits for
-         * string formatting
-         */
-        static double round(double val, int decimal_digits) {
-            if (decimal_digits == -1)
-                return val;
-            char out[64];
-            sprintf(out, "%.*f", decimal_digits, val);
-            return strtod(out, NULL);
-        }
 };
 
 class DataConverter {

--- a/libmodmqttconv/converter.hpp
+++ b/libmodmqttconv/converter.hpp
@@ -157,7 +157,7 @@ class ConverterTools {
             if (decimal_digits == -1)
                 return val;
             double divider = pow(10, decimal_digits);
-            int dummy = (int)(val * divider);
+            double dummy = val * divider;
             return dummy / divider;
         }
 };

--- a/libmodmqttconv/converter.hpp
+++ b/libmodmqttconv/converter.hpp
@@ -156,9 +156,9 @@ class ConverterTools {
         static double round(double val, int decimal_digits) {
             if (decimal_digits == -1)
                 return val;
-            double divider = pow(10, decimal_digits);
-            double dummy = val * divider;
-            return dummy / divider;
+            char out[64];
+            sprintf(out, "%.*f", decimal_digits, val);
+            return strtod(out, NULL);
         }
 };
 

--- a/libmodmqttconv/mqttvalue.hpp
+++ b/libmodmqttconv/mqttvalue.hpp
@@ -48,7 +48,6 @@ class MqttValue {
             setDouble(val, precision);
         }
 
-
         MqttValue(const void* ptr, size_t size){
             mBinaryValue = std::shared_ptr<void>(malloc(size), free);
             memcpy(mBinaryValue.get(), ptr, size);

--- a/libmodmqttconv/mqttvalue.hpp
+++ b/libmodmqttconv/mqttvalue.hpp
@@ -206,9 +206,9 @@ class MqttValue {
          * round double value to decimal_digits for
          * string formatting
          */
-        static double round(double input, int precision) {
+        static double round(double value, int precision) {
             double divisor = pow(10, precision);
-            return std::round(input * divisor) / divisor;
+            return std::round(value * divisor) / divisor;
         }
 
         //https://codereview.stackexchange.com/questions/90565/converting-a-double-to-a-stdstring-without-scientific-notation

--- a/libmodmqttconv/mqttvalue.hpp
+++ b/libmodmqttconv/mqttvalue.hpp
@@ -5,7 +5,6 @@
 #include <variant>
 #include <string>
 #include <sstream>
-#include <iomanip>
 #include <limits>
 #include <memory>
 
@@ -22,9 +21,6 @@ class MqttValue {
             BINARY = 2,
             INT64 = 3
         } SourceType;
-
-        static const int DEFAULT_DOUBLE_PRECISION = 6;
-        static const int MAX_DOUBLE_PRECISION = std::numeric_limits<double>::digits10;
 
         static MqttValue fromInt(int32_t val) {
             return MqttValue(val);
@@ -74,7 +70,7 @@ class MqttValue {
         }
 
         void setDouble(double val, int precision) {
-            mValue.v_double = round(val, precision);
+            mValue.v_double = precision < 0 ? val : round(val, precision);
             mType = SourceType::DOUBLE;
         }
 
@@ -212,12 +208,13 @@ class MqttValue {
         size_t mBinarySize;
         SourceType mType;
 
+        /**
+         * round double value to decimal_digits for
+         * string formatting
+         */
         static double round(double input, int precision) {
-            double output;
-            std::stringstream ss;
-            ss << std::fixed << std::setprecision(precision < 0 ? DEFAULT_DOUBLE_PRECISION : precision) << input;
-            ss >> output;
-            return output;
+            double divisor = pow(10, precision);
+            return std::round(input * divisor) / divisor;
         }
 
         //https://codereview.stackexchange.com/questions/90565/converting-a-double-to-a-stdstring-without-scientific-notation

--- a/libmodmqttconv/mqttvalue.hpp
+++ b/libmodmqttconv/mqttvalue.hpp
@@ -1,13 +1,7 @@
 #pragma once
 
-#include <cstdint>
 #include <cstring>
-#include <variant>
-#include <string>
-#include <sstream>
-#include <limits>
 #include <memory>
-
 #include "convexception.hpp"
 
 class MqttValue {

--- a/stdconv/divide.hpp
+++ b/stdconv/divide.hpp
@@ -25,7 +25,7 @@ class DivideConverter : public DataConverter {
         }
 
         virtual void setArgs(const std::vector<std::string>& args) {
-            mDivider = ConverterTools::getDoubleArg(0, args);
+            mDivisor = ConverterTools::getDoubleArg(0, args);
             if (args.size() > 1) {
                 mPrecision = ConverterTools::getIntArg(1, args);
             }
@@ -37,12 +37,11 @@ class DivideConverter : public DataConverter {
 
         virtual ~DivideConverter() {}
     private:
-        double mDivider;
-        int mPrecision = MqttValue::DEFAULT_DOUBLE_PRECISION;
+        double mDivisor;
+        int mPrecision = -1;
         bool mLowFirst = false;
 
         double doMath(double value) const {
-            double ret = value / mDivider;
-            return ret;
+            return value / mDivisor;
         }
 };

--- a/stdconv/divide.hpp
+++ b/stdconv/divide.hpp
@@ -7,14 +7,13 @@ class DivideConverter : public DataConverter {
     public:
         virtual MqttValue toMqtt(const ModbusRegisters& data) const {
 
+            double val;
             if (data.getCount() == 1) {
-                int16_t val = data.getValue(0);
-                return MqttValue::fromDouble(doMath(val));
+                val = data.getValue(0);
+            } else {
+                val = ConverterTools::registersToInt32(data.values(), mLowFirst);
             }
-            else {
-                int32_t val = ConverterTools::registersToInt32(data.values(), mLowFirst);
-                return MqttValue::fromDouble(doMath(val));
-            }
+            return MqttValue::fromDouble(doMath(val), mPrecision);
             //TODO uint16, uint32, float as separate data_type arg
         }
 
@@ -26,9 +25,9 @@ class DivideConverter : public DataConverter {
         }
 
         virtual void setArgs(const std::vector<std::string>& args) {
-            divider = ConverterTools::getDoubleArg(0, args);
+            mDivider = ConverterTools::getDoubleArg(0, args);
             if (args.size() > 1) {
-                precision = ConverterTools::getIntArg(1, args);
+                mPrecision = ConverterTools::getIntArg(1, args);
             }
             if (args.size() > 2) {
                 std::string first_byte = ConverterTools::getArg(2, args);
@@ -38,13 +37,12 @@ class DivideConverter : public DataConverter {
 
         virtual ~DivideConverter() {}
     private:
-        double divider;
-        int precision = -1;
+        double mDivider;
+        int mPrecision = MqttValue::DEFAULT_DOUBLE_PRECISION;
         bool mLowFirst = false;
 
         double doMath(double value) const {
-            double ret = value / divider;
-            ret = ConverterTools::round(ret, precision);
+            double ret = value / mDivider;
             return ret;
         }
 };

--- a/stdconv/float32.hpp
+++ b/stdconv/float32.hpp
@@ -52,5 +52,5 @@ class FloatConverter : public DataConverter {
     private:
         bool mLowFirst = false;
         bool mSwapBytes = false;
-        int mPrecision = MqttValue::DEFAULT_DOUBLE_PRECISION;
+        int mPrecision = -1;
 };

--- a/stdconv/float32.hpp
+++ b/stdconv/float32.hpp
@@ -14,7 +14,7 @@ class FloatConverter : public DataConverter {
                 ConverterTools::swapByteOrder(converted);
             int32_t int_val = ConverterTools::registersToInt32(converted, mLowFirst);
             double val = *reinterpret_cast<float*>(&int_val);
-            return MqttValue::fromDouble(ConverterTools::round(val, mPrecision));
+            return MqttValue::fromDouble(val, mPrecision);
         }
 
         virtual ModbusRegisters toModbus(const MqttValue& value, int registerCount) const {
@@ -52,5 +52,5 @@ class FloatConverter : public DataConverter {
     private:
         bool mLowFirst = false;
         bool mSwapBytes = false;
-        int mPrecision = -1;
+        int mPrecision = MqttValue::DEFAULT_DOUBLE_PRECISION;
 };

--- a/stdconv/scale.hpp
+++ b/stdconv/scale.hpp
@@ -12,7 +12,7 @@ class ScaleConverter : public DataConverter {
                 + targetScaleFrom;
 
             if (precision != 0)
-                targetValue = round(targetValue, precision);
+                targetValue = ConverterTools::round(targetValue, precision);
 
             return MqttValue::fromDouble(targetValue);
         }
@@ -34,10 +34,4 @@ class ScaleConverter : public DataConverter {
         double targetScaleFrom;
         double targetScaleTo;
         int precision = 0;
-
-        static double round(double val, int decimal_digits) {
-            double divider = pow(10, decimal_digits);
-            int dummy = (int)(val * divider);
-            return dummy / divider;
-        }
 };

--- a/stdconv/scale.hpp
+++ b/stdconv/scale.hpp
@@ -11,10 +11,7 @@ class ScaleConverter : public DataConverter {
                 * (sourceValue - sourceScaleFrom)/(sourceScaleTo - sourceScaleFrom)
                 + targetScaleFrom;
 
-            if (precision != 0)
-                targetValue = ConverterTools::round(targetValue, precision);
-
-            return MqttValue::fromDouble(targetValue);
+            return MqttValue::fromDouble(targetValue, precision);
         }
 
         virtual void setArgs(const std::vector<std::string>& args) {

--- a/unittests/exprconv_tests.cpp
+++ b/unittests/exprconv_tests.cpp
@@ -74,7 +74,7 @@ TEST_CASE("A 32-bit number should be converted by exprtk") {
 
             MqttValue output = conv->toMqtt(input);
 
-            REQUIRE_THAT(output.getDouble(), Catch::Matchers::WithinULP(expected, 0));;
+            REQUIRE_THAT(output.getDouble(), Catch::Matchers::WithinULP(expected, 0));
             REQUIRE(output.getString() == expectedString);
         }
 
@@ -84,7 +84,7 @@ TEST_CASE("A 32-bit number should be converted by exprtk") {
 
             MqttValue output = conv->toMqtt(input);
 
-            REQUIRE_THAT(output.getDouble(), Catch::Matchers::WithinULP(expected, 0));;
+            REQUIRE_THAT(output.getDouble(), Catch::Matchers::WithinULP(expected, 0));
             REQUIRE(output.getString() == expectedString);
         }
 
@@ -94,7 +94,7 @@ TEST_CASE("A 32-bit number should be converted by exprtk") {
 
             MqttValue output = conv->toMqtt(input);
 
-            REQUIRE_THAT(output.getDouble(), Catch::Matchers::WithinULP(expected, 0));;
+            REQUIRE_THAT(output.getDouble(), Catch::Matchers::WithinULP(expected, 0));
             REQUIRE(output.getString() == expectedString);
         }
 
@@ -104,7 +104,7 @@ TEST_CASE("A 32-bit number should be converted by exprtk") {
 
             MqttValue output = conv->toMqtt(input);
 
-            REQUIRE_THAT(output.getDouble(), Catch::Matchers::WithinULP(expected, 0));;
+            REQUIRE_THAT(output.getDouble(), Catch::Matchers::WithinULP(expected, 0));
             REQUIRE(output.getString() == expectedString);
         }
 

--- a/unittests/exprconv_tests.cpp
+++ b/unittests/exprconv_tests.cpp
@@ -74,7 +74,7 @@ TEST_CASE("A 32-bit number should be converted by exprtk") {
 
             MqttValue output = conv->toMqtt(input);
 
-            REQUIRE(output.getDouble() == expected);
+            REQUIRE(static_cast<float>(output.getDouble()) == expected);
             REQUIRE(output.getString() == expectedString);
         }
 
@@ -84,7 +84,7 @@ TEST_CASE("A 32-bit number should be converted by exprtk") {
 
             MqttValue output = conv->toMqtt(input);
 
-            REQUIRE(output.getDouble() == expected);
+            REQUIRE(static_cast<float>(output.getDouble()) == expected);
             REQUIRE(output.getString() == expectedString);
         }
 
@@ -94,7 +94,7 @@ TEST_CASE("A 32-bit number should be converted by exprtk") {
 
             MqttValue output = conv->toMqtt(input);
 
-            REQUIRE(output.getDouble() == expected);
+            REQUIRE(static_cast<float>(output.getDouble()) == expected);
             REQUIRE(output.getString() == expectedString);
         }
 
@@ -104,7 +104,7 @@ TEST_CASE("A 32-bit number should be converted by exprtk") {
 
             MqttValue output = conv->toMqtt(input);
 
-            REQUIRE(output.getDouble() == expected);
+            REQUIRE(static_cast<float>(output.getDouble()) == expected);
             REQUIRE(output.getString() == expectedString);
         }
 

--- a/unittests/exprconv_tests.cpp
+++ b/unittests/exprconv_tests.cpp
@@ -74,7 +74,7 @@ TEST_CASE("A 32-bit number should be converted by exprtk") {
 
             MqttValue output = conv->toMqtt(input);
 
-            REQUIRE(static_cast<float>(output.getDouble()) == expected);
+            REQUIRE_THAT(output.getDouble(), Catch::Matchers::WithinULP(expected, 0));;
             REQUIRE(output.getString() == expectedString);
         }
 
@@ -84,7 +84,7 @@ TEST_CASE("A 32-bit number should be converted by exprtk") {
 
             MqttValue output = conv->toMqtt(input);
 
-            REQUIRE(static_cast<float>(output.getDouble()) == expected);
+            REQUIRE_THAT(output.getDouble(), Catch::Matchers::WithinULP(expected, 0));;
             REQUIRE(output.getString() == expectedString);
         }
 
@@ -94,7 +94,7 @@ TEST_CASE("A 32-bit number should be converted by exprtk") {
 
             MqttValue output = conv->toMqtt(input);
 
-            REQUIRE(static_cast<float>(output.getDouble()) == expected);
+            REQUIRE_THAT(output.getDouble(), Catch::Matchers::WithinULP(expected, 0));;
             REQUIRE(output.getString() == expectedString);
         }
 
@@ -104,7 +104,7 @@ TEST_CASE("A 32-bit number should be converted by exprtk") {
 
             MqttValue output = conv->toMqtt(input);
 
-            REQUIRE(static_cast<float>(output.getDouble()) == expected);
+            REQUIRE_THAT(output.getDouble(), Catch::Matchers::WithinULP(expected, 0));;
             REQUIRE(output.getString() == expectedString);
         }
 

--- a/unittests/jsonutils.cpp
+++ b/unittests/jsonutils.cpp
@@ -8,5 +8,7 @@ void REQUIRE_JSON(const std::string& current, const char* expected) {
     d_current.Parse(current.c_str());
     d_expected.Parse(expected);
 
+    CAPTURE(current.c_str());
+    CAPTURE(expected);
     REQUIRE(d_current == d_expected);
 }

--- a/unittests/scheduler_tests.cpp
+++ b/unittests/scheduler_tests.cpp
@@ -40,7 +40,6 @@ TEST_CASE( "Modbus scheduler single register tests" ) {
 
         CHECK(duration == std::chrono::milliseconds(800));
         REQUIRE(poll.size() == 0);
-        std::cerr << "dur: " << std::chrono::duration_cast<std::chrono::milliseconds>(duration).count() << std::endl;
     }
 
 }

--- a/unittests/stdconv_float_tests.cpp
+++ b/unittests/stdconv_float_tests.cpp
@@ -66,7 +66,7 @@ TEST_CASE("A float32 value should be read") {
         MqttValue output = conv->toMqtt(input);
 
 
-        REQUIRE(output.getString() == "-123.45");
+        REQUIRE(output.getString() == "-123.46");
     }
 
 }

--- a/unittests/stdconv_float_tests.cpp
+++ b/unittests/stdconv_float_tests.cpp
@@ -23,8 +23,7 @@ TEST_CASE("A float32 value should be read") {
 
         MqttValue output = conv->toMqtt(input);
 
-
-        REQUIRE(static_cast<float>(output.getDouble()) == expected);
+        REQUIRE_THAT(output.getDouble(), Catch::Matchers::WithinULP(expected, 0));
         REQUIRE(output.getString() == expectedString);
     }
 
@@ -34,7 +33,7 @@ TEST_CASE("A float32 value should be read") {
         conv->setArgs(std::vector<std::string>({"-1", "low_first"}));
         MqttValue output = conv->toMqtt(input);
 
-        REQUIRE(static_cast<float>(output.getDouble()) == expected);
+        REQUIRE_THAT(output.getDouble(), Catch::Matchers::WithinULP(expected, 0));;
         REQUIRE(output.getString() == expectedString);
     }
 
@@ -44,7 +43,7 @@ TEST_CASE("A float32 value should be read") {
         conv->setArgs(std::vector<std::string>({"-1", "high_first", "swap_bytes"}));
         MqttValue output = conv->toMqtt(input);
 
-        REQUIRE(static_cast<float>(output.getDouble()) == expected);
+        REQUIRE_THAT(output.getDouble(), Catch::Matchers::WithinULP(expected, 0));;
         REQUIRE(output.getString() == expectedString);
     }
 
@@ -55,7 +54,7 @@ TEST_CASE("A float32 value should be read") {
         conv->setArgs(std::vector<std::string>({"-1", "low_first", "swap_bytes"}));
         MqttValue output = conv->toMqtt(input);
 
-        REQUIRE(static_cast<float>(output.getDouble()) == expected);
+        REQUIRE_THAT(output.getDouble(), Catch::Matchers::WithinULP(expected, 0));;
         REQUIRE(output.getString() == expectedString);
     }
 

--- a/unittests/stdconv_float_tests.cpp
+++ b/unittests/stdconv_float_tests.cpp
@@ -24,7 +24,7 @@ TEST_CASE("A float32 value should be read") {
         MqttValue output = conv->toMqtt(input);
 
 
-        REQUIRE(output.getDouble() == expected);
+        REQUIRE(static_cast<float>(output.getDouble()) == expected);
         REQUIRE(output.getString() == expectedString);
     }
 
@@ -34,7 +34,7 @@ TEST_CASE("A float32 value should be read") {
         conv->setArgs(std::vector<std::string>({"-1", "low_first"}));
         MqttValue output = conv->toMqtt(input);
 
-        REQUIRE(output.getDouble() == expected);
+        REQUIRE(static_cast<float>(output.getDouble()) == expected);
         REQUIRE(output.getString() == expectedString);
     }
 
@@ -44,7 +44,7 @@ TEST_CASE("A float32 value should be read") {
         conv->setArgs(std::vector<std::string>({"-1", "high_first", "swap_bytes"}));
         MqttValue output = conv->toMqtt(input);
 
-        REQUIRE(output.getDouble() == expected);
+        REQUIRE(static_cast<float>(output.getDouble()) == expected);
         REQUIRE(output.getString() == expectedString);
     }
 
@@ -55,7 +55,7 @@ TEST_CASE("A float32 value should be read") {
         conv->setArgs(std::vector<std::string>({"-1", "low_first", "swap_bytes"}));
         MqttValue output = conv->toMqtt(input);
 
-        REQUIRE(output.getDouble() == expected);
+        REQUIRE(static_cast<float>(output.getDouble()) == expected);
         REQUIRE(output.getString() == expectedString);
     }
 

--- a/unittests/stdconv_float_tests.cpp
+++ b/unittests/stdconv_float_tests.cpp
@@ -115,6 +115,4 @@ TEST_CASE("A float32 value should be written") {
 
         REQUIRE(converted.values() == expected.values());
     }
-
-
 }


### PR DESCRIPTION
This PR fixes floating point related issues. The issues can be reproduced when building for target platform `linux/386`.

Logs:
* [Complete build log demonstrating the issues](https://gitlab.com/ckware/mqmgateway/-/jobs/4776150270)
* [Complete build log after fixing the issues](https://gitlab.com/ckware/mqmgateway/-/jobs/4793075986)

Excerpt from the build log:

```
#51 0.608 /opt/mqmgateway/source/unittests/exprconv_tests.cpp:122
#51 0.608 ...........................................................................................................................................................................................................................................................................................................
#51 0.608 
#51 0.609 /opt/mqmgateway/source/unittests/exprconv_tests.cpp:136: FAILED:
#51 0.609   REQUIRE( output.getString() == "-1" )
#51 0.609 with expansion:
#51 0.609   "-32768" == "-1"
...
#51 1.373 /opt/mqmgateway/source/unittests/mqtt_named_scalar_conv_tests.cpp:36
#51 1.373 ...........................................................................................................................................................................................................................................................................................................
#51 1.373 
#51 1.373 /opt/mqmgateway/source/unittests/jsonutils.cpp:11: FAILED:
#51 1.373   REQUIRE( d_current == d_expected )
#51 1.373 with expansion:
#51 1.373   {?} == {?}
...
#51 1.666 /opt/mqmgateway/source/unittests/mqtt_state_map_conv_tests.cpp:35
#51 1.666 ...........................................................................................................................................................................................................................................................................................................
#51 1.666 
#51 1.666 /opt/mqmgateway/source/unittests/jsonutils.cpp:11: FAILED:
#51 1.666   REQUIRE( d_current == d_expected )
#51 1.666 with expansion:
#51 1.666   {?} == {?}
#51 1.666 
```

The test failures seem to be caused by casts between `double` and `int`. I can't tell why this only happens on i386 platform, though; could be related to different [compiler defaults for floating point](https://gcc.gnu.org/onlinedocs/gcc-3.1/gcc/i386-and-x86-64-Options.html) calculations (just a guess).

#### Problem 1
`exprconv_tests:136`: `int16_t(regValue)` results in `-32768` instead of `-1`.
The fix uses the `toNumber()` function, as all other custom functions do.
I also had success with `int16_t(static_cast<uint16_t>(regValue))`.

#### Problem 2
The other 2 tests fail because of a diff in the JSON document:
   - `mqtt_state_map_conv_tests:35`:
      ```
      current.c_str(): {"sensor1":12.339,"sensor2":10.0}
      expected: {"sensor1": 12.34, "sensor2": 10.0}
      ```
   - `mqtt_named_scalar_conv_tests:36`:
      ```
      current.c_str(): {"some_name":3245.599}
      expected: { "some_name": 3245.6}
      ```
This problem can be narrowed down to the `dummy` variable in `ConverterTools::round()`; it seems to be caused by casts between `double` and `int`.

#### Conclusion
After struggling with these rounding related issues, I have a suggestion. I think that in `ConverterTools`:
```c
static double round(double val, int decimal_digits)
```
should be replaced by

```c
static std::string format(double val, int decimal_digits)
```

The reason is that there's no proper way to round a floating point variable to an exact value. The converters apply roundings just before creating an MqttValue, finally resulting in a string in the JSON. So in my opinion it's safer to return a string instead of a double as rounding result, to be sure that the value looks exactly as requested.

The only location that uses the rounding result as number is `DivideConverter.toModbus()`, but the value is stored as  `int32_t` so the effect of rounding looks quite limited to me.

If you agree that rounding should result in a `string` instead of a `double`, I will open another PR.
