### PR TITLE
Docker support with GitHub CI build

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,113 @@
+name: ci
+
+on:
+  push:
+    branches:
+      - "feature/ci"
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ghcr.io/${{ github.repository }}
+
+# permissions are needed if pushing to ghcr.io
+permissions:
+  packages: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: true
+      matrix:
+        platform:
+          - linux/amd64
+          - linux/arm/v6
+          - linux/arm/v7
+          - linux/arm64
+          - linux/i386
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v3
+      -
+        name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: ${{ env.IMAGE_NAME }}
+      -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      -
+        name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      -
+        name: Build and push by digest
+        id: build
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          platforms: ${{ matrix.platform }}
+          labels: ${{ steps.meta.outputs.labels }}
+          outputs: type=image,name=${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true
+          build-args: |
+            MQM_TEST_DEFAULT_WAIT_MS=400
+      -
+        name: Export digest
+        run: |
+          mkdir -p /tmp/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"
+      -
+        name: Upload digest
+        uses: actions/upload-artifact@v3
+        with:
+          name: digests
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  merge:
+    runs-on: ubuntu-latest
+    needs:
+      - build
+    steps:
+      -
+        name: Download digests
+        uses: actions/download-artifact@v3
+        with:
+          name: digests
+          path: /tmp/digests
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      -
+        name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: ${{ env.IMAGE_NAME }}
+      -
+        name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      -
+        name: Create manifest list and push
+        working-directory: /tmp/digests
+        run: |
+          docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf '${{ env.IMAGE_NAME }}@sha256:%s ' *)
+      -
+        name: Inspect image
+        run: |
+          docker buildx imagetools inspect ${{ env.IMAGE_NAME }}:${{ steps.meta.outputs.version }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,36 @@
+ARG ALPINE_VERSION=latest
+FROM alpine:${ALPINE_VERSION} AS builder
+RUN apk update && apk add --no-cache \
+      git build-base cmake pkgconf boost-dev libmodbus-dev mosquitto-dev yaml-cpp-dev rapidjson-dev catch2
+
+ARG EXPRTK_URL=https://github.com/ArashPartow/exprtk/raw/master/exprtk.hpp
+RUN if [ "${EXPRTK_URL-}" ]; then \
+      mkdir -p /usr/local/include && \
+      wget -O /usr/local/include/exprtk.hpp "${EXPRTK_URL}" || true; \
+    fi
+
+COPY . /opt/mqmgateway/source
+ARG MQM_TEST_SKIP
+RUN cmake \
+      -DCMAKE_INSTALL_PREFIX:PATH=/opt/mqmgateway/install \
+      ${MQM_TEST_SKIP:+-DWITHOUT_TESTS=1} \
+      -S /opt/mqmgateway/source \
+      -B /opt/mqmgateway/build
+WORKDIR /opt/mqmgateway/build
+RUN make -j$(nproc)
+ARG MQM_TEST_ALLOW_FAILURE=false
+ARG MQM_TEST_DEFAULT_WAIT_MS
+ARG MQM_TEST_LOGLEVEL=3
+RUN if [ -z "${MQM_TEST_SKIP}" ]; then cd unittests; ./tests || [ "${MQM_TEST_ALLOW_FAILURE}" = "true" ]; fi
+RUN make install
+
+FROM alpine:${ALPINE_VERSION} AS runtime
+COPY --from=builder /opt/mqmgateway/install/ /usr/
+COPY --from=builder /opt/mqmgateway/source/modmqttd/config.template.yaml /etc/modmqttd/config.yaml
+RUN apk update && apk add --no-cache \
+  $(apk search -e boost*-log | grep -o '^boost.*-log') \
+  $(apk search -e boost*-program_options | grep -o '^boost.*-program_options') \
+  libmodbus mosquitto yaml-cpp && \
+  apk cache purge
+ENTRYPOINT [ "/usr/bin/modmqttd" ]
+CMD [ "--config", "/etc/modmqttd/config.yaml" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 ARG ALPINE_VERSION=latest
 FROM alpine:${ALPINE_VERSION} AS builder
 RUN apk update && apk add --no-cache \
-      git build-base cmake pkgconf boost-dev libmodbus-dev mosquitto-dev yaml-cpp-dev rapidjson-dev catch2
+      git build-base cmake pkgconf boost-dev libmodbus-dev mosquitto-dev yaml-cpp-dev rapidjson-dev catch2-3
 
 ARG EXPRTK_URL=https://github.com/ArashPartow/exprtk/raw/master/exprtk.hpp
 RUN if [ "${EXPRTK_URL-}" ]; then \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,11 @@
+---
+services:
+  mqmgateway:
+    image: "ghcr.io/BlackZork/mqmgateway:feature-ci"
+    container_name: mqmgateway
+    init: true
+    restart: unless-stopped
+    volumes:
+      - "./config.yaml:/etc/modmqttd/config.yaml:ro"
+    devices:
+      - /dev/ttyUSB0


### PR DESCRIPTION
This PR is a proof-of-concept for a CI build of a Docker image on GitHub. It is has three parts:

* A `Dockerfile` for the build
* A GitHub workflow description `.github/workflows/main.yaml` for continuous integration
* A `docker-compose.yml` file to run a container

#### Build
The `Dockerfile` describes the build of an image. After downloading a base image of Alpine Linux and all required dependencies incl. exprtk, the C++ build is started and the tests are run. When that succeeds, the binaries are taken over into a new small image that only includes the runtime dependencies.

#### Continuous Integration
Whenever a commit is reaching branch `feature/ci`, a workflow is started via GitHub Actions. The workflow creates a Docker image for five platforms in parallel (multi-arch). When the build of an image succeeds, the image is pushed to the GitHub Container Registry. The image name is derived from the Git repository. When all builds succeed, a manifest list is created for the branch, so that the same image name may be used on any platform, e.g. `ghcr.io/BlackZork/mqmgateway:feature-ci`. The images are shown in GitHub on the right side of the repository in section _Packages_.

#### Runtime
The `docker-compose.yml` is the only file that a user requires to run the application, apart from a configuration file `config.yaml` expected in the same directory. The devices for Modbus RTU may be configured in the compose file. The application can be managed and monitored with standard compose commands, e.g. `docker compose up` to start or `docker compose logs` to view the logs.


#### Notes
* This configuration is meant as starting point. It was tested in my repository where everything may be inspected, e.g.
  * [Workflow Overview](https://github.com/git-developer/mqmgateway/actions)
  * [Package in the GitHub Container Registry](https://github.com/git-developer/mqmgateway/pkgs/container/mqmgateway)
* I'd like to merge into a new branch `feature/ci`, but I can only select existing branches as target. Thus I marked this PR as Draft.
* The build of branch [feature/ci](https://github.com/git-developer/mqmgateway/tree/feature/ci) is currently failing because it is based on `master` and misses the changed of `fix/i386`.
* The build of branch [feature/docker](https://github.com/git-developer/mqmgateway/tree/feature/docker) is based on `fix/i386` and succeeds.
