### PR TITLE
Prevent tests to fail in certain build environments

### DIFF
--- a/unittests/single_register_tests.cpp
+++ b/unittests/single_register_tests.cpp
@@ -77,8 +77,8 @@ mqtt:
 
         server.disconnectModbusSlave("tcptest", 1);
 
-        //max 4 sec for three register read attempts
-        server.waitForPublish("test_switch/availability", std::chrono::seconds(4));
+        //max 5 sec for three register read attempts
+        server.waitForPublish("test_switch/availability", std::chrono::seconds(5));
         REQUIRE(server.mqttValue("test_switch/availability") == "0");
         server.stop();
     }


### PR DESCRIPTION
This PR prevents tests to fail in certain build environments.

My CI Docker builds on GitHub run fine for Alpine base images and all archs `amd64`, `i386`, `arm64`, `arm/v7`, `arm/v6`. I recently added support for Debian base images and noticed that 1 single test fails reproduceably, but only on arch `arm/v6`. I first thought that adjusting `MQM_TEST_TIMEOUT` from 400ms could help, but it didn't for values up to 5000ms. Then I had a look at the test and found out that it uses a constant timeout. Changing this timeout from 4s to 5s fixes the problem.

I admit that the build enviromnent is quite special, but nevertheless it might be worth a fix.

See [here](https://github.com/git-developer/mqmgateway/actions/runs/7593045167) for a broken build and [here](https://github.com/git-developer/mqmgateway/actions/runs/7593872334) for a fixed one.