### PR TITLE
Fix minor issues in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -987,16 +987,16 @@ modbus:
   networks:
     - name: basement
       slaves:
-        - address: 1
-          name: meter1 
-          response_timeout: 50ms
-        - address: 2
-          name: meter2 
         - address: 1,2
           response_timeout: 100ms
           poll_groups:
             - register: 3
               count: 10
+        - address: 1
+          name: meter1 
+          response_timeout: 50ms
+        - address: 2
+          name: meter2 
 ```
 
 This example will set response timeout 100ms for both slaves - overriding value for slave1. Two poll groups are defined for reading registers 3-13 for both slaves.

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Cameron Desrochers. See license terms in [LICENSE.md](readerwriterqueue/LICENSE.
 ## From sources
 
 1. `git clone https://github.com/BlackZork/mqmgateway.git#branch=master`
-   
+
    You can aslo use `branch=<tagname>` to clone specific release or download sources from [Releases page](https://github.com/BlackZork/mqmgateway/releases)
 
 1. Install dependencies:
@@ -77,7 +77,7 @@ Cameron Desrochers. See license terms in [LICENSE.md](readerwriterqueue/LICENSE.
 
 ## Docker image
 
-Docker images for various archicetures (i386, arm6, arm7, amd64) are available in [packages section](https://github.com/users/BlackZork/packages/container/package/mqmgateway). 
+Docker images for various archicetures (i386, arm6, arm7, amd64) are available in [packages section](https://github.com/users/BlackZork/packages/container/package/mqmgateway).
 
 1. Pull docker image using instructions provided in packages section.
 
@@ -132,7 +132,7 @@ Modbus network configuration parameters are listed below:
 
 * **delay_before_first_command** (timespan, optional, default 0ms)
 
-  Required silence period before issuing first modbus command to a slave. This delay is applied only when gateway switches to a diffrent slave. 
+  Required silence period before issuing first modbus command to a slave. This delay is applied only when gateway switches to a diffrent slave.
 
   This option is useful for RTU networks with a mix of very slow and fast responding slaves. Adding a delay before slow slave
   can significantly reduce amount of read erorrs if mqmgateway is configured to poll very fast.
@@ -196,14 +196,14 @@ Modbus network configuration parameters are listed below:
 
     TCP port of a device
 
-* **watchdog** (optional)    
+* **watchdog** (optional)
 
   An optional configuration section for modbus connection watchdog. Watchdog monitors modbus command errors. If there is no successful command execution in *watch_period*, then it restarts the modbus connection.
 
   Additionally for RTU network the *device* path is checked on the first error and then in small (300ms) time periods. If modbus RTU device is unplugged, then connection is restarted.
 
   * **watch_period** (optional, timespan, default=10s)
-    
+
   The amount of time after which the connection should be reestablished if there has been no successful execution of a modbus command.
 
 * **slaves** (optional)
@@ -212,9 +212,9 @@ Modbus network configuration parameters are listed below:
   * **address** (required)
 
       Modbus slave address. Multiple comma-separated values or ranges are supported like this:
-          
+
           1,2,3-10,12,30
-          
+
 
   * **name** (optional)
 
@@ -257,8 +257,8 @@ Modbus network configuration parameters are listed below:
             count: 20
       ```
 
-      This definition allows to use single modbus read call to read all data that is needed 
-      for multiple topics declared in MQTT section. If there are no topics that use modbus data from 
+      This definition allows to use single modbus read call to read all data that is needed
+      for multiple topics declared in MQTT section. If there are no topics that use modbus data from
       a poll group then that poll group is ignored.
 
       If MQTT topic uses its own register range and this range overlaps a poll group like this:
@@ -589,7 +589,7 @@ Configuration values:
   * **converter** (optional)
 
     The name of function that should be called to convert register uint16_t values to MQTT UTF-8 value. Format of function name is `plugin_name.function_name`. See converters for details.
-    After conversion, MQTT value is compared to available_value. "1" is published if values are equal, 
+    After conversion, MQTT value is compared to available_value. "1" is published if values are equal,
     otherwise "0".
 
   * **available_value** (optional, default 1)
@@ -936,7 +936,7 @@ For more examples see libstdconv source code.
 
 Multi-device defintions allows to set slave properties or create a single topic for multiple modbus devices of the same type. This greatly reduces the number of configuration sections that differ only by slave address or modbus network name.
 
-### Multi-device MQTT topics 
+### Multi-device MQTT topics
 
 If there are many devices of the same type then a MQTT topic for group of devices can be defined by setting `slave` value to list of modbus slave addresses. Then you have to add either `slave_name` or `slave_address` placeholder in the topic string like this:
 
@@ -946,9 +946,9 @@ modbus:
     - name: basement
       slaves:
         - address: 1
-          name: meter1 
+          name: meter1
         - address: 2
-          name: meter2 
+          name: meter2
         [...]
 mqtt:
   objects:
@@ -993,10 +993,10 @@ modbus:
             - register: 3
               count: 10
         - address: 1
-          name: meter1 
+          name: meter1
           response_timeout: 50ms
         - address: 2
-          name: meter2 
+          name: meter2
 ```
 
 This example will set response timeout 100ms for both slaves - overriding value for slave1. Two poll groups are defined for reading registers 3-13 for both slaves.

--- a/README.md
+++ b/README.md
@@ -905,9 +905,8 @@ g++ -I<path to mqmgateway source dir> -fPIC -shared myplugin.cpp -o myplugin.so
 
 ```yaml
 modmqttd:
-  loglevel: 5
   converter_search_path:
-    - <mylugin.so dir>
+    - <myplugin.so dir>
   converter_plugins:
     - myplugin.so
 modbus:
@@ -974,7 +973,7 @@ modbus:
     - name: basement
       slaves:
         - address: 1,2,3,5-18
-          pool_groups:
+          poll_groups:
             - register: 3
               count: 10
             - register: 30
@@ -995,7 +994,7 @@ modbus:
           name: meter2 
         - address: 1,2
           response_timeout: 100ms
-          pool_groups:
+          poll_groups:
             - register: 3
               count: 10
 ```

--- a/README.md
+++ b/README.md
@@ -211,7 +211,7 @@ Modbus network configuration parameters are listed below:
 
   * **address** (required)
 
-      Modbus slave address. Mutiple comma-separated values or ranges are supported like this:
+      Modbus slave address. Multiple comma-separated values or ranges are supported like this:
           
           1,2,3-10,12,30
           
@@ -352,10 +352,10 @@ A list of topics where modbus values are published to MQTT broker and subscribed
 
     Sets default modbus slave address for all state, commands and availability sections in this topic.
 
-    Mutiple values are supported in for of comma separated list of numbers or number ranges like this:
+    Multiple values are supported as comma-separated list of numbers or number ranges like this:
 
-        1,2,3,5-18,21 
-    
+        1,2,3,5-18,21
+
     If more than one value is set, then you have to include `${slave_address}` or `${slave_name}` in `topic` value.
 
     For examples see [Multi-device definitions](#multi-device-definitions) section.
@@ -965,7 +965,7 @@ Slave names are required only if `${slave_name}` placeholder is used.
 
 ### Multi device modbus slave definitions.
 
-Address list can be used in `modbus.networks.slaves.address` to define properties for mutiple slaves at once:
+Address list can be used in `modbus.networks.slaves.address` to define properties for multiple slaves at once:
 
 ```yaml
 modbus:
@@ -980,7 +980,7 @@ modbus:
               count: 5
 ```
 
-A single slave address can be listed in mutiple entries like this:
+A single slave address can be listed in multiple entries like this:
 
 ```yaml
 modbus:

--- a/libmodmqttsrv/modmqtt.cpp
+++ b/libmodmqttsrv/modmqtt.cpp
@@ -501,7 +501,7 @@ ModMqtt::parseObject(
     if (yAvail.IsMap()) {
         MqttObjectDataNode node(parseObjectDataNode(yAvail, pDefaultNetwork, pDefaultSlaveId, pDefaultRefresh, pSpecsOut));
         if (!node.isScalar() && !node.hasConverter())
-            throw ConfigurationException(yAvail.Mark(), "mutiple registers availability must use a converter");
+            throw ConfigurationException(yAvail.Mark(), "multiple registers availability must use a converter");
         ret.addAvailabilityDataNode(node);
     } else {
         throw ConfigurationException(yState.Mark(), "availability must be a single register or a list with converter");

--- a/libmodmqttsrv/yaml_converters.hpp
+++ b/libmodmqttsrv/yaml_converters.hpp
@@ -62,7 +62,7 @@ struct YAML::convert<std::chrono::milliseconds> {
 };
 
 /**
- * A converter for list of itegers in format
+ * A converter for list of integers in format
  * 1,2,3,4-5,6
  *
  * For single number std::pair<number, number> is returned

--- a/unittests/mqtt_availablility_tests.cpp
+++ b/unittests/mqtt_availablility_tests.cpp
@@ -6,7 +6,7 @@
 #include "yaml_utils.hpp"
 
 
-TEST_CASE ("Availability from mutiple registers") {
+TEST_CASE ("Availability from multiple registers") {
 
 static TestConfig config(R"(
 modmqttd:

--- a/unittests/mqtt_poll_groups_tests.cpp
+++ b/unittests/mqtt_poll_groups_tests.cpp
@@ -57,7 +57,7 @@ mqtt:
         available_value: 1
 )";
 
-TEST_CASE ("Topic state data should be pulled as pull group") {
+TEST_CASE ("Topic state data should be polled as poll group") {
     MockedModMqttServerThread server(config1);
     server.setModbusRegisterValue("tcptest", 1, 2, modmqttd::RegisterType::INPUT, 1);
     server.setModbusRegisterValue("tcptest", 1, 3, modmqttd::RegisterType::INPUT, 1);
@@ -113,7 +113,7 @@ mqtt:
 )";
 
 
-TEST_CASE ("Unchanged state should not be published when pulled as a pull group") {
+TEST_CASE ("Unchanged state should not be published when polled as a poll group") {
     MockedModMqttServerThread server(config2);
     server.setModbusRegisterValue("tcptest", 1, 1, modmqttd::RegisterType::INPUT, 1);
     server.setModbusRegisterValue("tcptest", 1, 2, modmqttd::RegisterType::INPUT, 2);

--- a/unittests/mqtt_poll_groups_tests.cpp
+++ b/unittests/mqtt_poll_groups_tests.cpp
@@ -189,7 +189,7 @@ mqtt:
         - register: tcptest.1.4
 )";
 
-TEST_CASE ("Mutiple poll group definitions should be merged") {
+TEST_CASE ("Multiple poll group definitions should be merged") {
     MockedModMqttServerThread server(slave_sets_config);
     server.setModbusRegisterValue("tcptest", 1, 1, modmqttd::RegisterType::HOLDING, 1);
     server.setModbusRegisterValue("tcptest", 1, 2, modmqttd::RegisterType::HOLDING, 2);

--- a/unittests/scheduler_tests.cpp
+++ b/unittests/scheduler_tests.cpp
@@ -44,7 +44,7 @@ TEST_CASE("Modbus scheduler") {
         REQUIRE(poll.size() == 0);
     }
 
-    SECTION ("should return delay=mRefresh if register was pulled now") {
+    SECTION ("should return delay=mRefresh if register was polled now") {
         reg->mLastRead = now;
         RegisterSpec poll = scheduler.getRegistersToPoll(duration, now);
 


### PR DESCRIPTION
The only important change is the removal of `loglevel` from the config. It is supported as command line arg only.