### PR TITLE
CI: remove repo name from workflow file

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,16 +18,30 @@ on:
 
 env:
   REGISTRY: ghcr.io
-  # cannot use gitgub.repository due to my upper case username
-  REGISTRY_IMAGE: ghcr.io/blackzork/mqmgateway
+  REGISTRY_IMAGE: ghcr.io/${{ github.repository }}
 
 # permissions are needed if pushing to ghcr.io
 permissions:
   packages: write
 
 jobs:
+  setup:
+    runs-on: ubuntu-latest
+    outputs:
+      registry_image: ${{ steps.translation.outputs.registry_image }}
+    steps:
+      -
+        name: Translate registry image name to lower-case
+        id: translation
+        run: |
+          echo "registry_image=${REGISTRY_IMAGE@L}" >>"${GITHUB_OUTPUT}"
+
   build:
     runs-on: ubuntu-latest
+    needs:
+      - setup
+    env:
+      REGISTRY_IMAGE: ${{ needs.setup.outputs.registry_image }}
     strategy:
       fail-fast: true
       matrix:
@@ -42,7 +56,7 @@ jobs:
         name: Prepare
         run: |
           platform=${{ matrix.platform }}
-          echo "PLATFORM_PAIR=${platform//\//-}" >> $GITHUB_ENV  
+          echo "PLATFORM_PAIR=${platform//\//-}" >>"${GITHUB_ENV}"
       -
         name: Checkout
         uses: actions/checkout@v4
@@ -94,7 +108,10 @@ jobs:
   merge:
     runs-on: ubuntu-latest
     needs:
+      - setup
       - build
+    env:
+      REGISTRY_IMAGE: ${{ needs.setup.outputs.registry_image }}
     steps:
       -
         name: Download digests
@@ -123,7 +140,7 @@ jobs:
         name: Create manifest list and push
         working-directory: /tmp/digests
         run: |
-          docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+          docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "${DOCKER_METADATA_OUTPUT_JSON}") \
             $(printf '${{ env.REGISTRY_IMAGE }}@sha256:%s ' *)
       -
         name: Inspect image


### PR DESCRIPTION
This PR replaces the hard-coded image name with a lower-case translation of the repo name.

It simplifies building an image in forks of this repo.