### PR TITLE
Add TLS support for MQTT

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,7 +302,7 @@ The mqtt section contains broker definition and modbus register mappings. Mappin
 
     MQTT boker IP address
 
-  * **port** (optional, default 1883)
+  * **port** (optional, default 1883 for plain MQTT or 8883 for MQTT over TLS)
 
     MQTT broker TCP port
 
@@ -317,6 +317,15 @@ The mqtt section contains broker definition and modbus register mappings. Mappin
   * **password** (optional)
 
     The password to be used to connect to MQTT broker
+
+  * **tls** (optional)
+
+    This option enables TLS for connecting to MQTT broker
+
+    * **cafile** (optional)
+
+      Path to a file containing the PEM encoded trusted CA certificate files.
+      If this option is not set, OS provided CA certificates are used.
 
 * **objects** (required)
 

--- a/libmodmqttsrv/config.cpp
+++ b/libmodmqttsrv/config.cpp
@@ -75,6 +75,12 @@ ModbusNetworkConfig::ModbusNetworkConfig(const YAML::Node& source) {
 
 MqttBrokerConfig::MqttBrokerConfig(const YAML::Node& source) {
     mHost = ConfigTools::readRequiredString(source, "host");
+    if (source["tls"]) {
+        mTLS = true;
+        mPort = 8883;
+        const YAML::Node& tls = source["tls"];
+        ConfigTools::readOptionalValue<std::string>(mCafile, tls, "cafile");
+    }
     ConfigTools::readOptionalValue<int>(mPort, source, "port");
     ConfigTools::readOptionalValue<int>(mKeepalive, source, "keepalive");
     ConfigTools::readOptionalValue<std::string>(mUsername, source, "username");

--- a/libmodmqttsrv/config.hpp
+++ b/libmodmqttsrv/config.hpp
@@ -151,7 +151,7 @@ class MqttBrokerConfig {
                     mCafile == other.mCafile;
         }
 
-        //defaults are from mosqittopp.h
+        //defaults are from mosquittopp.h
         std::string mHost;
         int mPort = 1883;
         int mKeepalive = 60;

--- a/libmodmqttsrv/config.hpp
+++ b/libmodmqttsrv/config.hpp
@@ -146,7 +146,9 @@ class MqttBrokerConfig {
                     mPort == other.mPort &&
                     mKeepalive == other.mKeepalive &&
                     mUsername == other.mUsername &&
-                    mPassword == other.mPassword;
+                    mPassword == other.mPassword &&
+                    mTLS == other.mTLS &&
+                    mCafile == other.mCafile;
         }
 
         //defaults are from mosqittopp.h
@@ -157,6 +159,9 @@ class MqttBrokerConfig {
         std::string mPassword;
 
         std::string mClientId;
+
+        bool mTLS = false;
+        std::string mCafile;
 };
 
 }

--- a/libmodmqttsrv/mosquitto.cpp
+++ b/libmodmqttsrv/mosquitto.cpp
@@ -103,6 +103,15 @@ Mosquitto::connect(const MqttBrokerConfig& config) {
     int rc = mosquitto_username_pw_set(mMosq, config.mUsername.c_str(), config.mPassword.c_str());
     throwOnCriticalError(rc);
 
+    if (config.mTLS) {
+      if (config.mCafile.empty()) {
+        rc = mosquitto_int_option(mMosq, MOSQ_OPT_TLS_USE_OS_CERTS, 1);
+      } else {
+        rc = mosquitto_tls_set(mMosq, config.mCafile.c_str(), NULL, NULL, NULL, NULL);
+      }
+      throwOnCriticalError(rc);
+    }
+
     rc = mosquitto_connect_async(
         mMosq, config.mHost.c_str(),
         config.mPort,

--- a/modmqttd/config.template.yaml
+++ b/modmqttd/config.template.yaml
@@ -21,9 +21,9 @@ modbus:
       parity: E
       data_bit: 8
       stop_bit: 1
-      
+
       # Optional settings for RTU 
-      
+
       #rtu_serial_mode: rs232
       #rtu_serial_mode: rs485
 
@@ -63,7 +63,7 @@ mqtt:
   refresh: 10s
   broker:
     host: localhost
-    # optional: default is 1883
+    # optional: default is 1883 for plain MQTT or 8883 for MQTT over TLS
     port: 1883
 
     # optional: default is 60sec
@@ -71,6 +71,10 @@ mqtt:
 
     # username: bob
     # password: secret
+
+    # tls:
+    #   cafile: /etc/modmqttd/ca.crt
+
   objects:
     - topic: isma_switch_1
       # default values used in all register: 
@@ -79,7 +83,7 @@ mqtt:
       slave: 1
       refresh: 1s
       commands:
-        - name: set 
+        - name: set
           register: 273
           register_type: coil
         # this declarating expect json list with size=4 from MQTT publish
@@ -105,7 +109,7 @@ mqtt:
           register_type: coil
         - register: tcptest.1.275
           register_type: coil
-          
+
     - topic: gtb_sensor/presence
       refresh: 1s
       state:
@@ -135,6 +139,3 @@ mqtt:
         register: rtutest.1.2
         count: 2
         register_type: input
-
-
-

--- a/unittests/CMakeLists.txt
+++ b/unittests/CMakeLists.txt
@@ -32,6 +32,7 @@ add_executable(tests
     mqtt_command_tests.cpp
     mqtt_command_only_tests.cpp
     mqtt_command_conv_tests.cpp
+    mqtt_config_tests.cpp
     mqtt_named_list_conv_tests.cpp
     mqtt_named_list_tests.cpp
     mqtt_named_scalar_conv_tests.cpp

--- a/unittests/modbus_config_tests.cpp
+++ b/unittests/modbus_config_tests.cpp
@@ -26,7 +26,7 @@ mqtt:
         register: tcptest.1.2
 )");
 
-    SECTION("shoud throw if response_timeout is outside range 0-999ms") {
+    SECTION("should throw if response_timeout is outside range 0-999ms") {
         config.mYAML["modbus"]["networks"][0]["response_timeout"] = "1s";
         MockedModMqttServerThread server(config.toString(), false);
         server.start();
@@ -34,7 +34,7 @@ mqtt:
         REQUIRE(server.initOk() == false);
     }
 
-    SECTION("shoud throw if response_data_timeout is outside range 0-999ms") {
+    SECTION("should throw if response_data_timeout is outside range 0-999ms") {
         config.mYAML["modbus"]["networks"][0]["response_data_timeout"] = "1s";
         MockedModMqttServerThread server(config.toString(), false);
         server.start();
@@ -60,7 +60,7 @@ mqtt:
       state:
 )");
 
-    SECTION("shoud throw if register list is empty") {
+    SECTION("should throw if register list is empty") {
         config.mYAML["mqtt"]["objects"][0]["state"]["registers"] = "";
         MockedModMqttServerThread server(config.toString(), false);
         server.start();
@@ -68,7 +68,7 @@ mqtt:
         REQUIRE(server.initOk() == false);
     }
 
-    SECTION("shoud throw if register map is empty") {
+    SECTION("should throw if register map is empty") {
         config.mYAML["mqtt"]["objects"][0]["state"][0]["name"] = "empty map";
         MockedModMqttServerThread server(config.toString(), false);
         server.start();
@@ -103,7 +103,7 @@ mqtt:
         register: tcptest.1.2
 )");
 
-    SECTION("shoud throw if expression is not valid") {
+    SECTION("should throw if expression is not valid") {
         MockedModMqttServerThread server(config.toString(), false);
         server.start();
         server.stop();

--- a/unittests/mqtt_availablility_tests.cpp
+++ b/unittests/mqtt_availablility_tests.cpp
@@ -33,7 +33,7 @@ mqtt:
         available_value: 65537
 )");
 
-SECTION ("shoud be set after conversion from register and count") {
+SECTION ("should be set after conversion from register and count") {
     config.mYAML["mqtt"]["objects"][0]["availability"]["register"] = "tcptest.1.2";
     config.mYAML["mqtt"]["objects"][0]["availability"]["count"] = "2";
 
@@ -53,7 +53,7 @@ SECTION ("shoud be set after conversion from register and count") {
     server.stop();
 }
 
-SECTION ("shoud be set after conversion from register list") {
+SECTION ("should be set after conversion from register list") {
     config.mYAML["mqtt"]["objects"][0]["availability"]["registers"].push_back(YAML::Node(YAML::NodeType::Map));
     config.mYAML["mqtt"]["objects"][0]["availability"]["registers"].push_back(YAML::Node(YAML::NodeType::Map));
 

--- a/unittests/mqtt_config_tests.cpp
+++ b/unittests/mqtt_config_tests.cpp
@@ -74,8 +74,6 @@ mqtt:
 
                 REQUIRE(cut.isSameAs(clone));
                 REQUIRE(clone.isSameAs(cut));
-                CAPTURE(cut.mCafile);
-                CAPTURE(other.mCafile);
                 REQUIRE_FALSE(cut.isSameAs(other));
                 REQUIRE_FALSE(other.isSameAs(cut));
             }

--- a/unittests/mqtt_config_tests.cpp
+++ b/unittests/mqtt_config_tests.cpp
@@ -1,0 +1,101 @@
+#include "catch2/catch_all.hpp"
+#include "config.hpp"
+#include "yaml_utils.hpp"
+
+using namespace modmqttd;
+
+TEST_CASE("MQTT configuration") {
+TestConfig config(R"(
+mqtt:
+  client_id: mqtt_test
+  broker:
+    host: localhost
+  objects:
+    - topic: test_sensor
+      state:
+        register: tcptest.1.2
+)");
+
+    SECTION("for broker") {
+        YAML::Node broker = config.mYAML["mqtt"]["broker"];
+
+        SECTION("without TLS node") {
+            MqttBrokerConfig cut(broker);
+
+            SECTION("should have TLS disabled and default port") {
+                REQUIRE_FALSE(cut.mTLS);
+                REQUIRE(cut.mPort == 1883);
+            }
+
+            SECTION("should be compared consistently to config with TLS") {
+                MqttBrokerConfig cut(broker);
+                MqttBrokerConfig clone(broker);
+                broker["tls"] = YAML::Node(YAML::NodeType::Map);
+                MqttBrokerConfig other(broker);
+
+                REQUIRE(cut.isSameAs(clone));
+                REQUIRE(clone.isSameAs(cut));
+                REQUIRE_FALSE(cut.isSameAs(other));
+                REQUIRE_FALSE(other.isSameAs(cut));
+            }
+        }
+
+        SECTION("with TLS node") {
+            broker["tls"] = YAML::Node(YAML::NodeType::Map);
+            YAML::Node tls = broker["tls"];
+            const int customPort = 2183;
+            const std::string cafile = "cafile";
+
+            SECTION("should have TLS enabled") {
+                MqttBrokerConfig cut(broker);
+
+                REQUIRE(cut.mTLS);
+            }
+
+            SECTION("without port node should have default TLS port") {
+                MqttBrokerConfig cut(broker);
+
+                REQUIRE(cut.mPort == 8883);
+            }
+
+            SECTION("and port node should have custom port") {
+                broker["port"] = customPort;
+                MqttBrokerConfig cut(broker);
+
+                REQUIRE(cut.mPort == customPort);
+            }
+
+            SECTION("and without cafile should be compared consistently to config with cafile") {
+                MqttBrokerConfig cut(broker);
+                MqttBrokerConfig clone(broker);
+                tls["cafile"] = cafile;
+                MqttBrokerConfig other(broker);
+
+                REQUIRE(cut.isSameAs(clone));
+                REQUIRE(clone.isSameAs(cut));
+                CAPTURE(cut.mCafile);
+                CAPTURE(other.mCafile);
+                REQUIRE_FALSE(cut.isSameAs(other));
+                REQUIRE_FALSE(other.isSameAs(cut));
+            }
+
+            SECTION("and cafile") {
+                tls["cafile"] = cafile;
+
+                SECTION("should have cafile") {
+                    MqttBrokerConfig cut(broker);
+
+                    REQUIRE(cut.mCafile == cafile);
+                }
+
+                SECTION("should be compared consistently") {
+                    MqttBrokerConfig cut(broker);
+                    MqttBrokerConfig clone(broker);
+
+                    REQUIRE(cut.isSameAs(clone));
+                    REQUIRE(clone.isSameAs(cut));
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
This PR adds basic TLS support for MQTT as requested in https://github.com/BlackZork/mqmgateway/discussions/51.

### Supported Features
The only supported feature is secure communication between application and broker. The application needs to know a trusted CA certificate for this. Users may choose between one of the following options:
1. Add an empty `mqtt.broker.tls` option to trust all OS provided certificates (usually located in `/etc/ssl/certs`)
    ```yaml
    mqtt:
      client_id: mqm-tls
      broker:
        host: broker
        tls:
    ```
2. Add the path to a CA file in option `mqtt.broker.tls.cafile`:
    ```yaml
    mqtt:
      client_id: mqm-tls
      broker:
        host: broker
        tls:
          cafile: /usr/local/lib/ca-certificates/ca.crt
    ```

### Try it
A [demo project](https://github.com/user-attachments/files/16220339/mqm-tls.tar.gz) is attached where functionality can be tested. It boots a container for the application and a second container for mosquitto, listening via TLS on default port 8883. Certificates are part of the demo project. To try it:
1. Unpack and enter the demo project: `tar -xvzf mqm-tls.tar.gz && cd mqm-tls`
1. Build a local image that contains demo certificates: `docker compose build`
1. Configure the modbus settings in `config.yaml`
1. Start the containers: `docker compose up -d`
1. Check that everything is up and running: `docker compose logs`
1. Subscribe via TLS to the broker and receive messages:
    `docker compose exec broker mosquitto_sub -v -L mqtts://broker/# --cafile /mosquitto/certs/ca.crt`

### Resources
- [mosquitto.h / TLS support](https://mosquitto.org/api/files/mosquitto-h.html#mosquitto_tls_set)
