### PR TITLE
added std.timestamp() converter

### DIFF
--- a/stdconv/plugin.cpp
+++ b/stdconv/plugin.cpp
@@ -11,6 +11,7 @@
 #include "single_arg_ops.hpp"
 #include "string.hpp"
 #include "uint32.hpp"
+#include "timestamp.hpp"
 
 DataConverter*
 StdConvPlugin::getConverter(const std::string& name) {
@@ -40,5 +41,7 @@ StdConvPlugin::getConverter(const std::string& name) {
         return new BitConverter();
     else if (name == "map")
         return new MapConverter();
+    else if (name == "timestamp")
+        return new TimestampGenerator();
     return nullptr;
 }

--- a/stdconv/timestamp.hpp
+++ b/stdconv/timestamp.hpp
@@ -1,0 +1,49 @@
+#include <boost/config.hpp> // for BOOST_SYMBOL_EXPORT
+#include <boost/date_time/posix_time/posix_time.hpp>
+#include <boost/date_time/posix_time/conversion.hpp>
+#include "libmodmqttconv/converterplugin.hpp"
+
+class TimestampGenerator : public DataConverter {
+    public:
+        //called by modmqttd to set coverter arguments
+        virtual void setArgs(const std::vector<std::string>& args) {
+            if (args.size() == 0) {
+                format = "";
+                return;
+            }
+            format = ConverterTools::getArg(0, args);
+        }
+
+        // Conversion from modbus registers to mqtt value
+        // Used when converter is defined for state topic
+        // ModbusRegisters contains one register or as many as
+        // configured in unnamed register list.
+        virtual MqttValue toMqtt(const ModbusRegisters& data) const {
+            boost::posix_time::ptime timestamp = boost::posix_time::second_clock::local_time();
+
+            if (format == "") {
+                tm tm = boost::posix_time::to_tm(timestamp);
+                return MqttValue::fromInt64(mktime(&tm));
+            }
+
+            boost::posix_time::time_facet* facet = new boost::posix_time::time_facet();
+            facet->format(format.c_str());
+            std::stringstream stream;
+            stream.imbue(std::locale(std::locale::classic(), facet));
+
+            stream << timestamp;
+
+            return MqttValue::fromString(stream.str());
+        }
+
+        // Conversion from mqtt value to modbus register data
+        // Used when converter is defined for command topic
+        virtual ModbusRegisters toModbus(const MqttValue& value, int registerCount) const {
+            ModbusRegisters ret;
+            return ret;
+        }
+
+        virtual ~TimestampGenerator() {}
+    private:
+      std::string format;
+};


### PR DESCRIPTION
This PR adds the option to generate a timestamp when sending a register

```
        - name: timestamp
          register: 8
          register_type: input
          converter: std.timestamp()
```
Optionally, a format can be passed to `std.timestamp("format")` as specified [here](https://www.boost.org/doc/libs/1_35_0/doc/html/date_time/date_time_io.html#date_time.format_flags)