### PR TITLE
docs: use lower case for container image

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 ---
 services:
   mqmgateway:
-    image: "ghcr.io/BlackZork/mqmgateway:master"
+    image: ghcr.io/blackzork/mqmgateway
     container_name: mqmgateway
     init: true
     restart: unless-stopped


### PR DESCRIPTION
Image names are lower case only, see example commands in the [package registry](https://github.com/BlackZork/mqmgateway/pkgs/container/mqmgateway). Upper case may cause an error in some environments.

Addittionally, I suggest omitting the `master` tag, defaulting to `latest` which is common for container images.