### PR TITLE
Fix documentation on expr functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -961,11 +961,10 @@ Register values are defined as `R0..Rn` variables.
   Custom functions for 16-bit numbers `[A,B]`:
   * `int16(R0)`: Cast uint16 value from `R0` == `AB` to int16
   * `int16bs(R0)`: Cast uint16 value from `R0` == `BA` to int16
-  * `uint16(R0)`: Read uint16 value from `R0` == `AB`
   * `uint16bs(R0)`: Read uint16 value from `R0` == `BA`
 
   All of the above functions can be used as `write_as` helper to store an expression value in modbus registers during writing. 
-  Additionally, the `low_first` argument can be used to store `ABCD` int32/float value as `RO`=`CD`, `R1`=`BA`.
+  Additionally, the `low_first` argument can be used to store `ABCD` int32/float value as `RO`=`CD`, `R1`=`AB`.
 
 #### Examples
 


### PR DESCRIPTION
The docs advertise a exprtk function `uint16(R0)` which is not available:

```
Exprtk ERR239 - Undefined symbol: 'uint16'
```

It is not part of the code:
https://github.com/BlackZork/mqmgateway/blob/ec356158a19dc4f9ce68d8886325741673067b6c/exprconv/expr.hpp#L111-L113

IMHO this is no problem because `R0` already means `uint16`, so there's no need for such a function (although it could be added for the sake of symmetry).

The second change addresses what looks like a typo to me.