### PR TITLE
stdconv: match string cleanup with array allocation

### DIFF
--- a/stdconv/map.hpp
+++ b/stdconv/map.hpp
@@ -92,7 +92,7 @@ class MapConverter : public DataConverter {
 
                 void dispose() {
                     if (!mIsInt && mMqttValue.mStr != nullptr)
-                        delete mMqttValue.mStr;
+                        delete[] mMqttValue.mStr;
                 }
 
                 ~Mapping() {}


### PR DESCRIPTION
## Summary

- Match MapConverter::Mapping string cleanup with its new[] allocation.
- Keep the existing map conversion behavior unchanged.

## Verification

- Reproduced the baseline alloc-dealloc-mismatch with an ASan harness exercising the real MapConverter parser and string conversion path.
- The same harness passes with ASan after the change.
- The same harness passes with -Wall -Wextra -Werror after excluding pre-existing unused-parameter and implicit-fallthrough warnings.
- git-clang-format --diff and git diff --check pass.
- The full CMake/Catch2 suite was not run locally because this environment does not have the repository's external build dependencies installed.